### PR TITLE
EXC-715: Add support for Ledger's transfer endpoint. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
         "text-encoding": "^0.7.0",
         "ts-jest": "^27.0.7",
         "ts-protoc-gen": "^0.15.0",
-        "typescript": "^4.5.2"
+        "typescript": "^4.5.2",
+        "whatwg-fetch": "^3.6.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6123,6 +6124,12 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -10789,6 +10796,12 @@
       "requires": {
         "makeerror": "1.0.12"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "text-encoding": "^0.7.0",
     "ts-jest": "^27.0.7",
     "ts-protoc-gen": "^0.15.0",
-    "typescript": "^4.5.2"
+    "typescript": "^4.5.2",
+    "whatwg-fetch": "^3.6.2"
   },
   "dependencies": {
     "@dfinity/agent": "^0.10.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { Ledger } from "./ledger";
+export { LedgerCanister } from "./ledger";
 export { AccountIdentifier, SubAccount } from "./account_identifier";
 export { ICP } from "./icp";

--- a/src/ledger.test.ts
+++ b/src/ledger.test.ts
@@ -1,0 +1,112 @@
+import { AccountIdentifier, ICP, LedgerCanister } from ".";
+import {
+  InsufficientFunds,
+  InvalidSender,
+  TxCreatedInFuture,
+  TxDuplicate,
+  TxTooOld,
+} from "./ledger";
+
+describe("LedgerCanister.transfer", () => {
+  it("handles invalid sender", async () => {
+    const ledger = LedgerCanister.create({
+      updateCallOverride: () => {
+        return Promise.resolve(
+          Error(`Reject code: 5
+            Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'Sending from 2vxsx-fae is not allowed', rosetta-api/ledger_canister/src/main.rs:135:9`)
+        );
+      },
+    });
+
+    const res = await ledger.transfer(
+      AccountIdentifier.fromHex(
+        "3e8bbceef8b9338e56a1b561a127326e6614894ab9b0739df4cc3664d40a5958"
+      ),
+      ICP.fromE8s(BigInt(100000))
+    );
+
+    expect(res).toBeInstanceOf(InvalidSender);
+  });
+
+  it("handles duplicate transaction", async () => {
+    const ledger = LedgerCanister.create({
+      updateCallOverride: () => {
+        return Promise.resolve(
+          Error(`Reject code: 5
+            Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'transaction is a duplicate of another transaction in block 1235123', rosetta-api/ledger_canister/src/main.rs:135:9`)
+        );
+      },
+    });
+
+    const res = await ledger.transfer(
+      AccountIdentifier.fromHex(
+        "3e8bbceef8b9338e56a1b561a127326e6614894ab9b0739df4cc3664d40a5958"
+      ),
+      ICP.fromE8s(BigInt(100000))
+    );
+
+    expect(res).toEqual(new TxDuplicate(BigInt(1235123)));
+  });
+
+  it("handles insufficient balance", async () => {
+    const ledger = LedgerCanister.create({
+      updateCallOverride: () => {
+        return Promise.resolve(
+          Error(`Reject code: 5
+            Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'the debit account doesn't have enough funds to complete the transaction, current balance: 123.46789123', rosetta-api/ledger_canister/src/main.rs:135:9`)
+        );
+      },
+    });
+
+    const res = await ledger.transfer(
+      AccountIdentifier.fromHex(
+        "3e8bbceef8b9338e56a1b561a127326e6614894ab9b0739df4cc3664d40a5958"
+      ),
+      ICP.fromE8s(BigInt(100000))
+    );
+
+    expect(res).toEqual(
+      new InsufficientFunds(ICP.fromE8s(BigInt(12346789123)))
+    );
+  });
+
+  it("handles future tx", async () => {
+    const ledger = LedgerCanister.create({
+      updateCallOverride: () => {
+        return Promise.resolve(
+          Error(`Reject code: 5
+            Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'transaction's created_at_time is in future', rosetta-api/ledger_canister/src/main.rs:135:9`)
+        );
+      },
+    });
+
+    const res = await ledger.transfer(
+      AccountIdentifier.fromHex(
+        "a2a794c66495083317e4be5197eb655b1e63015469d769e2338af3d3e3f3aa86"
+      ),
+      ICP.fromE8s(BigInt(100000))
+    );
+
+    expect(res).toEqual(new TxCreatedInFuture());
+  });
+
+  it("handles old tx", async () => {
+    const ledger = LedgerCanister.create({
+      updateCallOverride: () => {
+        return Promise.resolve(
+          Error(`Reject code: 5
+            Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'transaction is older than 123 seconds', rosetta-api/ledger_canister/src/main.rs:135:9`)
+        );
+      },
+    });
+
+    const res = await ledger.transfer(
+      AccountIdentifier.fromHex(
+        "3e8bbceef8b9338e56a1b561a127326e6614894ab9b0739df4cc3664d40a5958"
+      ),
+      ICP.fromE8s(BigInt(100000))
+    );
+
+    expect(res).toEqual(new TxTooOld(123));
+  });
+});

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -1,51 +1,202 @@
 import { Agent, AnonymousIdentity, HttpAgent } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
-import { AccountBalanceRequest, ICPTs } from "../proto/ledger_pb";
+import {
+  AccountBalanceRequest,
+  BlockHeight as PbBlockHeight,
+  ICPTs,
+  Memo,
+  Payment,
+  SendRequest,
+} from "../proto/ledger_pb";
 import { AccountIdentifier } from "./account_identifier";
 import { ICP } from "./icp";
-import { submitQueryRequest, submitUpdateRequest } from "./utils/proto";
+import { updateCall, queryCall } from "./utils/proto";
 
-const MAINNET_LEDGER_CANISTER_ID = Principal.fromText("ryjl3-tyaaa-aaaaa-aaaba-cai");
+const MAINNET_LEDGER_CANISTER_ID = Principal.fromText(
+  "ryjl3-tyaaa-aaaaa-aaaba-cai"
+);
 
-export class Ledger {
-    private readonly agent: Agent;
-    private readonly canisterId: Principal;
+type BlockHeight = bigint;
 
-    private constructor(agent: Agent, canisterId: Principal) {
-        this.agent = agent;
-        this.canisterId = canisterId;
+export type TransferError =
+  | InvalidSender
+  | InsufficientFunds
+  | TxTooOld
+  | TxCreatedInFuture
+  | TxDuplicate
+  | BadFee;
+
+export class InvalidSender {}
+export class BadFee {}
+export class InsufficientFunds {
+  constructor(public readonly balance: ICP) {}
+}
+export class TxTooOld {
+  constructor(public readonly allowed_window_secs: number) {}
+}
+export class TxCreatedInFuture {}
+export class TxDuplicate {
+  constructor(public readonly duplicateOf: BlockHeight) {}
+}
+
+type Fetcher = (
+  agent: Agent,
+  canisterId: Principal,
+  methodName: string,
+  arg: ArrayBuffer
+) => Promise<Uint8Array | Error>;
+
+// HttpAgent options that can be used at construction.
+export interface LedgerCanisterOptions {
+  // The agent to use when communicating with the ledger canister.
+  agent?: Agent;
+  // The ledger canister's ID.
+  canisterId?: Principal;
+  // The method to use for performing an update call. Primarily overridden
+  // in test for mocking.
+  updateCallOverride?: Fetcher;
+  // The method to use for performing a query call. Primarily overridden
+  // in test for mocking.
+  queryCallOverride?: Fetcher;
+}
+
+export class LedgerCanister {
+  private constructor(
+    private readonly agent: Agent,
+    private readonly canisterId: Principal,
+    private readonly updateFetcher: Fetcher,
+    private readonly queryFetcher: Fetcher
+  ) {}
+
+  public static create(options: LedgerCanisterOptions = {}) {
+    return new LedgerCanister(
+      options.agent ?? defaultAgent(),
+      options.canisterId ?? MAINNET_LEDGER_CANISTER_ID,
+      options.updateCallOverride ?? updateCall,
+      options.queryCallOverride ?? queryCall
+    );
+  }
+
+  /**
+   * Returns the balance of the specified account identifier.
+   *
+   * If `certified` is true, the request is fetched as an update call, otherwise
+   * it is fetched using a query call.
+   */
+  public accountBalance = async (
+    accountIdentifier: AccountIdentifier,
+    certified = true
+  ): Promise<ICP> => {
+    const callMethod = certified ? this.updateFetcher : this.queryFetcher;
+
+    const request = new AccountBalanceRequest();
+    request.setAccount(accountIdentifier.toProto());
+    const responseBytes = await callMethod(
+      this.agent,
+      this.canisterId,
+      "account_balance_pb",
+      request.serializeBinary()
+    );
+
+    if (responseBytes instanceof Error) {
+      // An error is never expected from this endpoint.
+      throw Error;
     }
 
-    public static create(agent = defaultAgent(), canisterId = MAINNET_LEDGER_CANISTER_ID) {
-        return new Ledger(agent, canisterId);
+    return ICP.fromE8s(
+      BigInt(ICPTs.deserializeBinary(new Uint8Array(responseBytes)).getE8s())
+    );
+  };
+
+  /**
+   * Transfer ICP from the caller to the destination `accountIdentifier`.
+   * Returns the index of the block containing the tx if it was successful.
+   *
+   * TODO: support remaining options (subaccounts, memos, etc.)
+   */
+  public transfer = async (
+    to: AccountIdentifier,
+    amount: ICP,
+    memo?: bigint
+  ): Promise<BlockHeight | TransferError> => {
+    const request = new SendRequest();
+    request.setTo(to.toProto());
+
+    const payment = new Payment();
+    payment.setReceiverGets(amount.toProto());
+    request.setPayment(payment);
+
+    if (memo) {
+      const memo = new Memo();
+      memo.setMemo(memo.toString());
+      request.setMemo(memo);
     }
 
-    public getBalance = async (
-        accountIdentifier: AccountIdentifier,
-        certified = true
-    ): Promise<ICP> => {
-        const request = new AccountBalanceRequest();
-        request.setAccount(accountIdentifier.toProto());
+    const responseBytes = await this.updateFetcher(
+      this.agent,
+      this.canisterId,
+      "send_pb",
+      request.serializeBinary()
+    );
 
-        const callMethod = certified ? submitUpdateRequest : submitQueryRequest;
+    if (responseBytes instanceof Error) {
+      if (responseBytes.message.includes("Reject code: 5")) {
+        // Match against the different error types.
+        // This string matching is fragile. It's a stop-gap solution until
+        // we migrate to the candid interface.
 
-        const responseBytes = await callMethod(
-            this.agent,
-            this.canisterId,
-            "account_balance_pb",
-            request.serializeBinary()
-        );
+        if (responseBytes.message.match(/Sending from (.*) is not allowed/)) {
+          return new InvalidSender();
+        }
 
-        return ICP.fromE8s(BigInt(ICPTs.deserializeBinary(new Uint8Array(responseBytes)).getE8s()));
-    };
+        {
+          const m = responseBytes.message.match(
+            /transaction.*duplicate.* in block (\d+)/
+          );
+          if (m && m.length > 1) {
+            return new TxDuplicate(BigInt(m[1]));
+          }
+        }
+
+        {
+          const m = responseBytes.message.match(
+            /debit account.*, current balance: (\d*(\.\d*)?)/
+          );
+          if (m && m.length > 1) {
+            const balance = ICP.fromString(m[1]);
+            if (balance instanceof ICP) {
+              return new InsufficientFunds(balance);
+            }
+          }
+        }
+
+        if (responseBytes.message.includes("is in future")) {
+          return new TxCreatedInFuture();
+        }
+
+        {
+          const m = responseBytes.message.match(/older than (\d+)/);
+          if (m && m.length > 1) {
+            return new TxTooOld(Number.parseInt(m[1]));
+          }
+        }
+      }
+
+      // Unknown error. Throw as-is.
+      throw responseBytes;
+    }
+
+    // Successful tx. Return the block height.
+    return BigInt(PbBlockHeight.deserializeBinary(responseBytes).getHeight());
+  };
 }
 
 /**
  * @returns The default agent to use. An agent that connects to mainnet with the anonymous identity.
  */
 function defaultAgent(): Agent {
-    return new HttpAgent({
-        host: "https://ic0.app",
-        identity: new AnonymousIdentity(),
-    });
+  return new HttpAgent({
+    host: "https://ic0.app",
+    identity: new AnonymousIdentity(),
+  });
 }

--- a/test-setup.ts
+++ b/test-setup.ts
@@ -1,2 +1,9 @@
 import textEncoding = require("text-encoding");
+const { Response, Request, Headers, fetch } = require("whatwg-fetch");
+
 global.TextEncoder = textEncoding.TextEncoder;
+global.TextDecoder = textEncoding.TextDecoder;
+global.Response = Response;
+global.Request = Request;
+global.Headers = Headers;
+global.fetch = fetch;


### PR DESCRIPTION
This PR adds support for the `transfer` endpoint. It's still missing
a few options (e.g. specifying a `memo`, or a `fromSubaccount`), but
these are easy to add later as needed.