### PR TITLE
Add a shebang line

### DIFF
--- a/proto/update_proto.sh
+++ b/proto/update_proto.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # A script for generating the JS of proto files.
 protoc \
 --plugin="protoc-gen-ts=./node_modules/.bin/protoc-gen-ts" \


### PR DESCRIPTION
# Motivation
A shell script without a shebang line fails shellcheck, the shell linter.  This can be observed if this codebase is copied into a codebase that uses shellcheck.

# Changes
- Add a shebang line