### PR TITLE
build: downgrade google-protobuf for nodejs environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3548,7 +3548,8 @@
     "node_modules/google-protobuf": {
       "version": "3.20.1",
       "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.20.1.tgz",
-      "integrity": "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw=="
+      "integrity": "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw==",
+      "dev": true
     },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
@@ -6233,7 +6234,7 @@
       "dependencies": {
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
-        "google-protobuf": "^3.20.1",
+        "google-protobuf": "^3.19.4",
         "js-sha256": "^0.9.0",
         "randombytes": "^2.1.0"
       },
@@ -6276,6 +6277,11 @@
       "peerDependencies": {
         "buffer": ">=6.0.3"
       }
+    },
+    "packages/nns/node_modules/google-protobuf": {
+      "version": "3.19.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.19.4.tgz",
+      "integrity": "sha512-OIPNCxsG2lkIvf+P5FNfJ/Km95CsXOBecS9ZcAU6m2Rq3svc0Apl9nB3GMDNKfQ9asNv4KjyAqGwPQFrVle3Yg=="
     },
     "packages/sns": {
       "name": "@dfinity/sns",
@@ -6751,7 +6757,7 @@
         "@types/randombytes": "^2.0.0",
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
-        "google-protobuf": "^3.20.1",
+        "google-protobuf": "3.19.4",
         "js-sha256": "^0.9.0",
         "randombytes": "^2.1.0"
       },
@@ -6771,6 +6777,11 @@
           "resolved": "https://registry.npmjs.org/crc/-/crc-4.1.1.tgz",
           "integrity": "sha512-2U3ZqJ2phJl9ANuP2q5VS53LMpNmYU9vcpmh6nutJmsqUREhtWpTRh9yYxG7sDg3xkwaEEXytSeffTxw4cgwPg==",
           "requires": {}
+        },
+        "google-protobuf": {
+          "version": "3.19.4",
+          "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.19.4.tgz",
+          "integrity": "sha512-OIPNCxsG2lkIvf+P5FNfJ/Km95CsXOBecS9ZcAU6m2Rq3svc0Apl9nB3GMDNKfQ9asNv4KjyAqGwPQFrVle3Yg=="
         }
       }
     },
@@ -8839,7 +8850,8 @@
     "google-protobuf": {
       "version": "3.20.1",
       "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.20.1.tgz",
-      "integrity": "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw=="
+      "integrity": "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "crc": "^4.1.1",
     "crc-32": "^1.2.2",
-    "google-protobuf": "^3.20.1",
+    "google-protobuf": "^3.19.4",
     "js-sha256": "^0.9.0",
     "randombytes": "^2.1.0"
   },


### PR DESCRIPTION
# Motivation

Workaround: downgrade google-protobuf to make nns-js lib works in NodeJs environment too.

Related to #143