### PR TITLE
fix: typo in root version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "2024.03.25-1415ZZ",
+  "version": "2024.03.25-1430Z",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/ic-js",
-      "version": "2024.03.25-1415ZZ",
+      "version": "2024.03.25-1430Z",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/utils",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "2024.03.25-1415ZZ",
+  "version": "2024.03.25-1430Z",
   "description": "A collection of library for interfacing with the Internet Computer.",
   "license": "Apache-2.0",
   "workspaces": [


### PR DESCRIPTION
# Motivation

There was a typo in #588 version number. `2024.03.25-1415ZZ`.

# Changes

- fix version
