### PR TITLE
chore: eslint for tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,7 @@
   "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "project": ["./tsconfig.json"]
+    "project": ["./tsconfig.eslint.json"]
   },
   "plugins": ["@typescript-eslint"],
   "ignorePatterns": [
@@ -13,9 +13,6 @@
     "*_pb.d.ts",
     "jest.config.js",
     "test-setup.ts",
-    "**/*.spec.ts",
-    "**/*.test.ts",
-    "**/*.mock.ts",
     "scripts/**/*"
   ],
   "rules": {

--- a/packages/ckbtc/src/bitcoin.canister.spec.ts
+++ b/packages/ckbtc/src/bitcoin.canister.spec.ts
@@ -1,6 +1,5 @@
-import { ActorSubclass } from "@dfinity/agent";
-import { bitcoinAddressMock } from "@dfinity/ic-management/src/ic-management.mock";
-import { CanisterOptions } from "@dfinity/utils/src";
+import type { ActorSubclass } from "@dfinity/agent";
+import type { CanisterOptions } from "@dfinity/utils";
 import { mock } from "jest-mock-extended";
 import type {
   _SERVICE as BitcoinService,
@@ -8,8 +7,8 @@ import type {
   satoshi,
 } from "../candid/bitcoin";
 import { BitcoinCanister } from "./bitcoin.canister";
-import { bitcoinCanisterIdMock } from "./mocks/minter.mock";
-import { GetBalanceParams, GetUtxosParams } from "./types/bitcoin.params";
+import { bitcoinAddressMock, bitcoinCanisterIdMock } from "./mocks/minter.mock";
+import type { GetBalanceParams, GetUtxosParams } from "./types/bitcoin.params";
 
 describe("BitcoinCanister", () => {
   const createBitcoinCanister = (

--- a/packages/ckbtc/src/minter.canister.spec.ts
+++ b/packages/ckbtc/src/minter.canister.spec.ts
@@ -1,18 +1,16 @@
-import { ActorSubclass } from "@dfinity/agent";
+import type { ActorSubclass } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { arrayOfNumberToUint8Array, toNullable } from "@dfinity/utils";
 import { mock } from "jest-mock-extended";
 import type {
   Account,
   _SERVICE as CkBTCMinterService,
-  RetrieveBtcStatusV2,
-  Utxo,
-} from "../candid/minter";
-import {
   RetrieveBtcError,
   RetrieveBtcOk,
   RetrieveBtcStatus,
+  RetrieveBtcStatusV2,
   UpdateBalanceError,
+  Utxo,
 } from "../candid/minter";
 import {
   MinterAlreadyProcessingError,
@@ -28,7 +26,7 @@ import {
 } from "./errors/minter.errors";
 import { CkBTCMinterCanister } from "./minter.canister";
 import { bitcoinAddressMock, minterCanisterIdMock } from "./mocks/minter.mock";
-import { UpdateBalanceOk } from "./types/minter.responses";
+import type { UpdateBalanceOk } from "./types/minter.responses";
 
 describe("ckBTC minter canister", () => {
   const minter = (

--- a/packages/cketh/src/minter.canister.spec.ts
+++ b/packages/cketh/src/minter.canister.spec.ts
@@ -1,8 +1,8 @@
-import { ActorSubclass } from "@dfinity/agent";
+import type { ActorSubclass } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { arrayOfNumberToUint8Array, toNullable } from "@dfinity/utils";
 import { mock } from "jest-mock-extended";
-import {
+import type {
   _SERVICE as CkETHMinterService,
   MinterInfo,
   RetrieveErc20Request,
@@ -58,7 +58,6 @@ describe("ckETH minter canister", () => {
 
       const canister = minter(service);
 
-      const owner = Principal.fromText("aaaaa-aa");
       const res = await canister.getSmartContractAddress();
       expect(service.smart_contract_address).toBeCalled();
       expect(res).toEqual(ckETHSmartContractAddressMock);
@@ -240,7 +239,7 @@ describe("ckETH minter canister", () => {
       const service = mock<ActorSubclass<CkETHMinterService>>();
 
       const error = { Err: { Test: null } as unknown };
-      // @ts-ignore we explicity want the results to throw some error type
+      // @ts-expect-error we explicity want the results to throw some error type
       service.withdraw_eth.mockResolvedValue(error);
 
       const canister = minter(service);
@@ -279,6 +278,7 @@ describe("ckETH minter canister", () => {
 
       expect(service.withdraw_erc20).toBeCalledTimes(1);
 
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { address, ledgerCanisterId, ...rest } = params;
       expect(service.withdraw_erc20).toBeCalledWith({
         recipient: address,
@@ -307,6 +307,7 @@ describe("ckETH minter canister", () => {
 
           expect(service.withdraw_erc20).toBeCalledTimes(1);
 
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { address, ledgerCanisterId, ...rest } = params;
           expect(service.withdraw_erc20).toHaveBeenCalledWith({
             recipient: address,
@@ -330,6 +331,7 @@ describe("ckETH minter canister", () => {
 
           expect(service.withdraw_erc20).toBeCalledTimes(1);
 
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { address, ledgerCanisterId, ...rest } = params;
           expect(service.withdraw_erc20).toHaveBeenCalledWith({
             recipient: address,
@@ -354,6 +356,7 @@ describe("ckETH minter canister", () => {
 
           expect(service.withdraw_erc20).toBeCalledTimes(1);
 
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { address, ledgerCanisterId, ...rest } = params;
           expect(service.withdraw_erc20).toHaveBeenCalledWith({
             recipient: address,
@@ -569,7 +572,7 @@ describe("ckETH minter canister", () => {
             },
           };
 
-          // @ts-ignore we explicity want the results to throw some error type
+          // @ts-expect-error we explicity want the results to throw some error type
           service.withdraw_erc20.mockResolvedValue(error);
 
           const canister = minter(service);
@@ -712,7 +715,7 @@ describe("ckETH minter canister", () => {
             },
           };
 
-          // @ts-ignore we explicity want the results to throw some error type
+          // @ts-expect-error we explicity want the results to throw some error type
           service.withdraw_erc20.mockResolvedValue(error);
 
           const canister = minter(service);
@@ -733,7 +736,7 @@ describe("ckETH minter canister", () => {
       const service = mock<ActorSubclass<CkETHMinterService>>();
 
       const error = { Err: { Test: null } as unknown };
-      // @ts-ignore we explicity want the results to throw some error type
+      // @ts-expect-error we explicity want the results to throw some error type
       service.withdraw_erc20.mockResolvedValue(error);
 
       const canister = minter(service);

--- a/packages/cketh/src/orchestrator.canister.spec.ts
+++ b/packages/cketh/src/orchestrator.canister.spec.ts
@@ -1,7 +1,7 @@
-import { ActorSubclass } from "@dfinity/agent";
+import type { ActorSubclass } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { mock } from "jest-mock-extended";
-import {
+import type {
   _SERVICE as CkETHOrchestratorService,
   ManagedCanisters,
   OrchestratorInfo,

--- a/packages/cmc/src/cmc.canister.spec.ts
+++ b/packages/cmc/src/cmc.canister.spec.ts
@@ -1,7 +1,7 @@
-import { ActorSubclass, HttpAgent } from "@dfinity/agent";
+import type { ActorSubclass, HttpAgent } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
+import type { QueryParams } from "@dfinity/utils";
 import { arrayOfNumberToUint8Array } from "@dfinity/utils";
-import type { QueryParams } from "@dfinity/utils/src";
 import { mock } from "jest-mock-extended";
 import type {
   _SERVICE as CMCService,

--- a/packages/ic-management/src/ic-management.canister.spec.ts
+++ b/packages/ic-management/src/ic-management.canister.spec.ts
@@ -1,5 +1,6 @@
-import { ActorSubclass, HttpAgent } from "@dfinity/agent";
-import { ServiceResponse, toNullable } from "@dfinity/utils";
+import type { ActorSubclass, HttpAgent } from "@dfinity/agent";
+import type { ServiceResponse } from "@dfinity/utils";
+import { toNullable } from "@dfinity/utils";
 import { mock } from "jest-mock-extended";
 import type {
   _SERVICE as IcManagementService,
@@ -15,9 +16,11 @@ import {
   mockPrincipal,
   mockPrincipalText,
 } from "./ic-management.mock";
-import {
+import type {
   CanisterSettings,
   InstallCodeParams,
+} from "./types/ic-management.params";
+import {
   InstallMode,
   LogVisibility,
   UnsupportedLogVisibility,
@@ -27,10 +30,8 @@ import {
   type StoredChunksParams,
   type UploadChunkParams,
 } from "./types/ic-management.params";
-import {
-  CanisterStatusResponse,
-  type FetchCanisterLogsResponse,
-} from "./types/ic-management.responses";
+import type { CanisterStatusResponse } from "./types/ic-management.responses";
+import { type FetchCanisterLogsResponse } from "./types/ic-management.responses";
 import { decodeSnapshotId } from "./utils/ic-management.utils";
 
 describe("ICManagementCanister", () => {
@@ -505,7 +506,7 @@ describe("ICManagementCanister", () => {
 
       const icManagement = await createICManagement(service);
 
-      const res = await icManagement.clearChunkStore(params);
+      await icManagement.clearChunkStore(params);
 
       expect(service.clear_chunk_store).toHaveBeenCalledWith({
         canister_id: params.canisterId,
@@ -676,15 +677,6 @@ describe("ICManagementCanister", () => {
 
   describe("fetchCanisterLogs", () => {
     it("returns canister logs when success", async () => {
-      const settings = {
-        freezing_threshold: BigInt(2),
-        controllers: [mockPrincipal],
-        memory_allocation: BigInt(4),
-        compute_allocation: BigInt(10),
-        reserved_cycles_limit: BigInt(11),
-        log_visibility: { controllers: null },
-        wasm_memory_limit: BigInt(500_00),
-      };
       const response: FetchCanisterLogsResponse = {
         canister_log_records: [
           {

--- a/packages/ic-management/src/ic-management.mock.ts
+++ b/packages/ic-management/src/ic-management.mock.ts
@@ -1,9 +1,7 @@
-import { Identity } from "@dfinity/agent";
+import type { Identity } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
-import {
-  CanisterSettings,
-  toCanisterSettings,
-} from "./types/ic-management.params";
+import type { CanisterSettings } from "./types/ic-management.params";
+import { toCanisterSettings } from "./types/ic-management.params";
 
 export const mockPrincipalText =
   "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe";

--- a/packages/ledger-icp/src/index.canister.spec.ts
+++ b/packages/ledger-icp/src/index.canister.spec.ts
@@ -1,6 +1,6 @@
-import { ActorSubclass } from "@dfinity/agent";
+import type { ActorSubclass } from "@dfinity/agent";
 import { mock } from "jest-mock-extended";
-import {
+import type {
   GetAccountIdentifierTransactionsError,
   GetAccountIdentifierTransactionsResponse,
   _SERVICE as IndexService,

--- a/packages/ledger-icp/src/ledger.canister.spec.ts
+++ b/packages/ledger-icp/src/ledger.canister.spec.ts
@@ -1,11 +1,13 @@
-import { ActorSubclass } from "@dfinity/agent";
+import type { ActorSubclass } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { arrayOfNumberToUint8Array } from "@dfinity/utils";
 import { mock } from "jest-mock-extended";
-import {
+import type {
   _SERVICE as LedgerService,
   Value,
   icrc21_consent_message_response,
+} from "../candid/ledger";
+import {
   type Account,
   type ApproveArgs as Icrc2ApproveRawRequest,
 } from "../candid/ledger";

--- a/packages/ledger-icrc/src/index-ng.canister.spec.ts
+++ b/packages/ledger-icrc/src/index-ng.canister.spec.ts
@@ -10,7 +10,7 @@ import type {
 import { IndexError } from "./errors/index.errors";
 import { IcrcIndexNgCanister } from "./index-ng.canister";
 import { indexCanisterIdMock, ledgerCanisterIdMock } from "./mocks/ledger.mock";
-import { IcrcAccount } from "./types/ledger.responses";
+import type { IcrcAccount } from "./types/ledger.responses";
 
 describe("Index canister", () => {
   afterEach(() => jest.clearAllMocks());

--- a/packages/ledger-icrc/src/index.canister.spec.ts
+++ b/packages/ledger-icrc/src/index.canister.spec.ts
@@ -9,7 +9,7 @@ import type {
 import { IndexError } from "./errors/index.errors";
 import { IcrcIndexCanister } from "./index.canister";
 import { indexCanisterIdMock, ledgerCanisterIdMock } from "./mocks/ledger.mock";
-import { IcrcAccount } from "./types/ledger.responses";
+import type { IcrcAccount } from "./types/ledger.responses";
 
 describe("Index canister", () => {
   afterEach(() => jest.clearAllMocks());

--- a/packages/ledger-icrc/src/ledger.canister.spec.ts
+++ b/packages/ledger-icrc/src/ledger.canister.spec.ts
@@ -1,4 +1,4 @@
-import { ActorSubclass } from "@dfinity/agent";
+import type { ActorSubclass } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { arrayOfNumberToUint8Array } from "@dfinity/utils";
 import { mock } from "jest-mock-extended";
@@ -24,7 +24,7 @@ import {
   mockPrincipal,
   tokenMetadataResponseMock,
 } from "./mocks/ledger.mock";
-import {
+import type {
   AllowanceParams,
   ApproveParams,
   Icrc21ConsentMessageParams,
@@ -315,7 +315,6 @@ describe("Ledger canister", () => {
         certifiedServiceOverride: service,
       });
 
-      const owner = Principal.fromText("aaaaa-aa");
       const res = await canister.allowance({
         ...allowanceParams,
         certified: true,

--- a/packages/ledger-icrc/src/mocks/ledger.mock.ts
+++ b/packages/ledger-icrc/src/mocks/ledger.mock.ts
@@ -1,5 +1,5 @@
 import { Principal } from "@dfinity/principal";
-import { MetadataValue } from "../../candid/icrc_ledger";
+import type { MetadataValue } from "../../candid/icrc_ledger";
 import { IcrcMetadataResponseEntries } from "../types/ledger.responses";
 
 export const tokenMetadataResponseMock: [

--- a/packages/nns/src/canisters/governance/request.converters.spec.ts
+++ b/packages/nns/src/canisters/governance/request.converters.spec.ts
@@ -6,7 +6,7 @@ import {
   CanisterInstallMode,
   LogVisibility,
 } from "../../enums/governance.enums";
-import { GovernanceParameters } from "../../types/governance_converters";
+import type { GovernanceParameters } from "../../types/governance_converters";
 import { toMakeProposalRawRequest } from "./request.converters";
 
 describe("request.converters", () => {
@@ -512,8 +512,6 @@ describe("request.converters", () => {
     });
 
     it("InstallCode", () => {
-      const principalId =
-        "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe";
       const summary = "Proposal summary";
 
       const mockRequest = {
@@ -568,8 +566,6 @@ describe("request.converters", () => {
     });
 
     it("StopOrStartCanister", () => {
-      const principalId =
-        "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe";
       const summary = "Proposal summary";
 
       const mockRequest = {
@@ -618,8 +614,6 @@ describe("request.converters", () => {
     });
 
     it("UpdateCanisterSettings", () => {
-      const principalId =
-        "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe";
       const summary = "Proposal summary";
 
       const mockRequest = {

--- a/packages/nns/src/genesis_token.canister.spec.ts
+++ b/packages/nns/src/genesis_token.canister.spec.ts
@@ -1,4 +1,4 @@
-import { ActorSubclass } from "@dfinity/agent";
+import type { ActorSubclass } from "@dfinity/agent";
 import { mock } from "jest-mock-extended";
 import type { _SERVICE as GenesisTokenService } from "../candid/genesis_token";
 import { GenesisTokenCanister } from "./genesis_token.canister";

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -1,13 +1,11 @@
-import { ActorSubclass, AnonymousIdentity } from "@dfinity/agent";
-import {
-  AccountIdentifier,
-  InvalidAccountIDError,
-  LedgerCanister,
-} from "@dfinity/ledger-icp";
+import type { ActorSubclass } from "@dfinity/agent";
+import { AnonymousIdentity } from "@dfinity/agent";
+import type { LedgerCanister } from "@dfinity/ledger-icp";
+import { AccountIdentifier, InvalidAccountIDError } from "@dfinity/ledger-icp";
 import { Principal } from "@dfinity/principal";
 import { InvalidPercentageError } from "@dfinity/utils";
 import { mock } from "jest-mock-extended";
-import {
+import type {
   ClaimOrRefreshNeuronFromAccountResponse,
   GovernanceError as GovernanceErrorDetail,
   _SERVICE as GovernanceService,
@@ -41,7 +39,7 @@ import {
   mockNeuronId,
   mockNeuronInfo,
 } from "./mocks/governance.mock";
-import {
+import type {
   Action,
   InstallCode,
   MakeProposalRequest,
@@ -287,7 +285,7 @@ describe("GovernanceCanister", () => {
       const governance = GovernanceCanister.create({
         certifiedServiceOverride: service,
       });
-      const response = await governance.stakeNeuron({
+      await governance.stakeNeuron({
         stake: BigInt(100_000_000),
         principal: new AnonymousIdentity().getPrincipal(),
         ledgerCanister: mockLedger,
@@ -1260,7 +1258,7 @@ describe("GovernanceCanister", () => {
       const governance = GovernanceCanister.create({
         serviceOverride: service,
       });
-      const response = await governance.claimOrRefreshNeuron({
+      await governance.claimOrRefreshNeuron({
         neuronId,
         by: { NeuronIdOrSubaccount: {} },
       });
@@ -1299,7 +1297,7 @@ describe("GovernanceCanister", () => {
       const governance = GovernanceCanister.create({
         certifiedServiceOverride: service,
       });
-      const response = await governance.joinCommunityFund(neuronId);
+      await governance.joinCommunityFund(neuronId);
       expect(service.manage_neuron).toBeCalled();
     });
 
@@ -1997,7 +1995,7 @@ describe("GovernanceCanister", () => {
       const governance = GovernanceCanister.create({
         certifiedServiceOverride: service,
       });
-      const response = await governance.stopDissolving(neuronId);
+      await governance.stopDissolving(neuronId);
       expect(service.manage_neuron).toBeCalled();
     });
 

--- a/packages/nns/src/governance_test.canister.spec.ts
+++ b/packages/nns/src/governance_test.canister.spec.ts
@@ -1,4 +1,4 @@
-import { ActorSubclass } from "@dfinity/agent";
+import type { ActorSubclass } from "@dfinity/agent";
 import { mock } from "jest-mock-extended";
 import type { _SERVICE as GovernanceService } from "../candid/governance_test";
 import { toNeuron } from "./canisters/governance/response.converters";

--- a/packages/nns/src/sns_wasm.canister.spec.ts
+++ b/packages/nns/src/sns_wasm.canister.spec.ts
@@ -1,4 +1,4 @@
-import { ActorSubclass } from "@dfinity/agent";
+import type { ActorSubclass } from "@dfinity/agent";
 import { mock } from "jest-mock-extended";
 import type { _SERVICE as SnsWasmService } from "../candid/sns_wasm";
 import { deployedSnsMock } from "./mocks/sns_wasm.mock";

--- a/packages/nns/src/utils/neurons.utils.spec.ts
+++ b/packages/nns/src/utils/neurons.utils.spec.ts
@@ -1,7 +1,7 @@
 import { Principal } from "@dfinity/principal";
 import { uint8ArrayToHexString } from "@dfinity/utils";
 import { Vote } from "../enums/governance.enums";
-import { NeuronInfo, ProposalInfo } from "../types/governance_converters";
+import type { NeuronInfo, ProposalInfo } from "../types/governance_converters";
 import {
   ineligibleNeurons,
   memoToNeuronAccountIdentifier,

--- a/packages/sns/src/governance.canister.spec.ts
+++ b/packages/sns/src/governance.canister.spec.ts
@@ -38,7 +38,7 @@ import {
   proposalsMock,
 } from "./mocks/governance.mock";
 import { rootCanisterIdMock } from "./mocks/sns.mock";
-import {
+import type {
   SnsDisburseNeuronParams,
   SnsNeuronDisburseMaturityParams,
   SnsRegisterVoteParams,
@@ -219,9 +219,7 @@ describe("Governance canister", () => {
 
     it("should raise an error if call fails", async () => {
       const service = mock<ActorSubclass<SnsGovernanceService>>();
-      const mockListProposals = service.list_proposals.mockRejectedValue(
-        new Error("error"),
-      );
+      service.list_proposals.mockRejectedValue(new Error("error"));
 
       const canister = SnsGovernanceCanister.create({
         canisterId: rootCanisterIdMock,
@@ -1061,7 +1059,6 @@ describe("Governance canister", () => {
     });
 
     it("should raise error", async () => {
-      const neuronId = { id: new Uint8Array() };
       const service = mock<ActorSubclass<SnsGovernanceService>>();
       service.manage_neuron.mockResolvedValue(mockErrorCommand);
 

--- a/packages/sns/src/mocks/sns.mock.ts
+++ b/packages/sns/src/mocks/sns.mock.ts
@@ -1,6 +1,6 @@
 import { Principal } from "@dfinity/principal";
 import type { ListSnsCanistersResponse } from "../../candid/sns_root";
-import { Ticket } from "../../candid/sns_swap";
+import type { Ticket } from "../../candid/sns_swap";
 
 export const rootCanisterIdMock: Principal = Principal.fromText(
   "pin7y-wyaaa-aaaaa-aacpa-cai",

--- a/packages/sns/src/sns.wrapper.spec.ts
+++ b/packages/sns/src/sns.wrapper.spec.ts
@@ -1,12 +1,15 @@
-import type { TransferParams } from "@dfinity/ledger-icrc";
-import { IcrcIndexCanister, IcrcLedgerCanister } from "@dfinity/ledger-icrc";
+import type {
+  IcrcIndexCanister,
+  IcrcLedgerCanister,
+  TransferParams,
+} from "@dfinity/ledger-icrc";
 import { Principal } from "@dfinity/principal";
 import { arrayOfNumberToUint8Array } from "@dfinity/utils";
 import { mock } from "jest-mock-extended";
-import { ManageNeuronResponse, NeuronId } from "../candid/sns_governance";
+import type { ManageNeuronResponse, NeuronId } from "../candid/sns_governance";
 import { SnsNeuronPermissionType, SnsVote } from "./enums/governance.enums";
 import { SnsGovernanceError } from "./errors/governance.errors";
-import { SnsGovernanceCanister } from "./governance.canister";
+import type { SnsGovernanceCanister } from "./governance.canister";
 import {
   metadataMock,
   neuronIdMock,
@@ -15,9 +18,9 @@ import {
   proposalIdMock,
 } from "./mocks/governance.mock";
 import { mockPrincipal, tokenMetadataResponseMock } from "./mocks/ledger.mock";
-import { SnsRootCanister } from "./root.canister";
+import type { SnsRootCanister } from "./root.canister";
 import { SnsWrapper } from "./sns.wrapper";
-import { SnsSwapCanister } from "./swap.canister";
+import type { SnsSwapCanister } from "./swap.canister";
 import type { SnsDisburseNeuronParams } from "./types/governance.params";
 
 describe("SnsWrapper", () => {

--- a/packages/utils/src/mocks/agent.mock.ts
+++ b/packages/utils/src/mocks/agent.mock.ts
@@ -1,5 +1,5 @@
 import type { HttpAgent } from "@dfinity/agent";
-import { AgentManagerConfig } from "../utils/agent.utils";
+import type { AgentManagerConfig } from "../utils/agent.utils";
 
 export const mockHttpAgent = {
   call: jest.fn().mockResolvedValue({

--- a/packages/utils/src/utils/asserts.utils.spec.ts
+++ b/packages/utils/src/utils/asserts.utils.spec.ts
@@ -40,7 +40,6 @@ describe("asserts-utils", () => {
       const getStringOrNull = (): string | null => "test";
       const value: string | null = getStringOrNull();
       assertNonNullish(value);
-      const nonNullValue: string = value;
     });
   });
 

--- a/packages/utils/src/utils/date.utils.spec.ts
+++ b/packages/utils/src/utils/date.utils.spec.ts
@@ -1,9 +1,6 @@
 import { describe } from "@jest/globals";
-import {
-  I18nSecondsToDuration,
-  nowInBigIntNanoSeconds,
-  secondsToDuration,
-} from "./date.utils";
+import type { I18nSecondsToDuration } from "./date.utils";
+import { nowInBigIntNanoSeconds, secondsToDuration } from "./date.utils";
 
 describe("date.utils", () => {
   const EN_TIME = {

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": []
+}


### PR DESCRIPTION
# Motivation

TIL our tests suite was not validated with eslint until today.

# Notes

I'll allow `_` as unused var in #769. Meanwhile I added four eslint ignore in tests in this PR.

# Changes

- Activate eslint for tests with a specific tsconfig.eslint.json that does not exclude the test
- Fix eslint issue in tests (mostly missing `import type` and few unused variables)

# Screenshots

<img width="1354" alt="Capture d’écran 2024-11-21 à 18 09 17" src="https://github.com/user-attachments/assets/d9a31546-4893-48be-b4a5-2d577bdc76ae">
<img width="1354" alt="Capture d’écran 2024-11-21 à 18 09 14" src="https://github.com/user-attachments/assets/ff9d8e8c-5a33-4bb0-8fd0-e9aeec300630">
<img width="1354" alt="Capture d’écran 2024-11-21 à 18 09 10" src="https://github.com/user-attachments/assets/32e0f119-b9e4-4d0c-be89-cd1a5d26c03f">
