### PR TITLE
feat: remove optional field `last_deposit_with_subaccount_scraped_block_number` from ckETH minter information.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 - Support `RefreshVotingPower` in `@dfinity/nns`.
+- Remove optional field `last_deposit_with_subaccount_scraped_block_number` from ckETH minter information.
 
 # 2024.11.27-1230Z
 

--- a/packages/cketh/candid/minter.certified.idl.js
+++ b/packages/cketh/candid/minter.certified.idl.js
@@ -264,7 +264,6 @@ export const idlFactory = ({ IDL }) => {
       )
     ),
     'minter_address' : IDL.Opt(IDL.Text),
-    'last_deposit_with_subaccount_scraped_block_number' : IDL.Opt(IDL.Nat),
     'ethereum_block_height' : IDL.Opt(BlockTag),
   });
   const EthTransaction = IDL.Record({ 'transaction_hash' : IDL.Text });

--- a/packages/cketh/candid/minter.d.ts
+++ b/packages/cketh/candid/minter.d.ts
@@ -256,7 +256,6 @@ export interface MinterInfo {
     | []
     | [Array<{ balance: bigint; erc20_contract_address: string }>];
   minter_address: [] | [string];
-  last_deposit_with_subaccount_scraped_block_number: [] | [bigint];
   ethereum_block_height: [] | [BlockTag];
 }
 export interface QueryStats {

--- a/packages/cketh/candid/minter.did
+++ b/packages/cketh/candid/minter.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 5d20289 (2024-11-21 tags: release-2024-11-21_03-11-24.04-base-kernel) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
+// Generated from IC repo commit f9085db (2024-11-28 tags: release-2024-11-28_03-15-revert-hashes-in-blocks) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
 type EthereumNetwork = variant {
     // The public Ethereum mainnet.
     Mainnet;
@@ -201,9 +201,6 @@ type MinterInfo = record {
 
     // Last scraped block number for logs of the ERC20 helper contract.
     last_erc20_scraped_block_number: opt nat;
-
-    // Last scraped block number for logs of the deposit with subaccount helper contract.
-    last_deposit_with_subaccount_scraped_block_number: opt nat;
 
     // Canister ID of the ckETH ledger.
     cketh_ledger_id: opt principal;

--- a/packages/cketh/candid/minter.idl.js
+++ b/packages/cketh/candid/minter.idl.js
@@ -264,7 +264,6 @@ export const idlFactory = ({ IDL }) => {
       )
     ),
     'minter_address' : IDL.Opt(IDL.Text),
-    'last_deposit_with_subaccount_scraped_block_number' : IDL.Opt(IDL.Nat),
     'ethereum_block_height' : IDL.Opt(BlockTag),
   });
   const EthTransaction = IDL.Record({ 'transaction_hash' : IDL.Text });

--- a/packages/cketh/candid/orchestrator.did
+++ b/packages/cketh/candid/orchestrator.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 5d20289 (2024-11-21 tags: release-2024-11-21_03-11-24.04-base-kernel) 'rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did' by import-candid
+// Generated from IC repo commit f9085db (2024-11-28 tags: release-2024-11-28_03-15-revert-hashes-in-blocks) 'rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did' by import-candid
 type OrchestratorArg = variant {
     UpgradeArg : UpgradeArg;
     InitArg : InitArg;

--- a/packages/cketh/src/minter.canister.spec.ts
+++ b/packages/cketh/src/minter.canister.spec.ts
@@ -867,7 +867,6 @@ describe("ckETH minter canister", () => {
         evm_rpc_id: toNullable(
           Principal.fromText("7hfb6-caaaa-aaaar-qadga-cai"),
         ),
-        last_deposit_with_subaccount_scraped_block_number: [],
       };
 
       const service = mock<ActorSubclass<CkETHMinterService>>();


### PR DESCRIPTION
# Motivation

The weekly update of Candid #780 does not pass because the test for ckETH are failing. The reason is the absence of the field `last_deposit_with_subaccount_scraped_block_number` in the minter information. 

I double checked with the cross chain team, this field never made it to mainnet.

# Changes

- Copy did types from #780 in this PR.
- Remove field from mock data.
