### PR TITLE
chore: prepare release version 72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
-# Next
+# v72
+
+## Overview
+
+| Library                  | Version | Status        |
+| ------------------------ | ------- | ------------- |
+| `@dfinity/ckbtc`         | v3.2.0  | Enhanced 🔧️  |
+| `@dfinity/cketh`         | v3.4.12 | Maintained ⚙️ |
+| `@dfinity/cmc`           | v5.0.8  | Maintained ⚙️ |
+| `@dfinity/ic-management` | v6.2.2  | Maintained ⚙️ |
+| `@dfinity/ledger-icp`    | v4.1.0  | Enhanced 🔧️  |
+| `@dfinity/ledger-icrc`   | v2.10.0 | Enhanced 🔧️  |
+| `@dfinity/nns`           | v9.1.0  | Enhanced 🔧️  |
+| `@dfinity/nns-proto`     | v2.0.2  | Unchanged️    |
+| `@dfinity/sns`           | v3.8.0  | Enhanced 🔧️  |
+| `@dfinity/utils`         | v2.14.0 | Enhanced 🔧️  |
+| `@dfinity/zod-schemas`   | v2.0.0  | Unchanged️    |
 
 ## Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "71",
+  "version": "72",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/ic-js",
-      "version": "71",
+      "version": "72",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/utils",
@@ -6721,7 +6721,7 @@
     },
     "packages/ckbtc": {
       "name": "@dfinity/ckbtc",
-      "version": "3.1.14",
+      "version": "3.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
@@ -6732,7 +6732,7 @@
         "@dfinity/agent": "^2.0.0",
         "@dfinity/candid": "^2.0.0",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.13.0"
+        "@dfinity/utils": "^2.14.0"
       }
     },
     "packages/ckbtc/node_modules/@noble/hashes": {
@@ -6759,62 +6759,62 @@
     },
     "packages/cketh": {
       "name": "@dfinity/cketh",
-      "version": "3.4.11",
+      "version": "3.4.12",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^2.0.0",
         "@dfinity/candid": "^2.0.0",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.13.0"
+        "@dfinity/utils": "^2.14.0"
       }
     },
     "packages/cmc": {
       "name": "@dfinity/cmc",
-      "version": "5.0.7",
+      "version": "5.0.8",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^2.0.0",
         "@dfinity/candid": "^2.0.0",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.13.0"
+        "@dfinity/utils": "^2.14.0"
       }
     },
     "packages/ic-management": {
       "name": "@dfinity/ic-management",
-      "version": "6.2.1",
+      "version": "6.2.2",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^2.0.0",
         "@dfinity/candid": "^2.0.0",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.13.0"
+        "@dfinity/utils": "^2.14.0"
       }
     },
     "packages/ledger-icp": {
       "name": "@dfinity/ledger-icp",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^2.0.0",
         "@dfinity/candid": "^2.0.0",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.13.0"
+        "@dfinity/utils": "^2.14.0"
       }
     },
     "packages/ledger-icrc": {
       "name": "@dfinity/ledger-icrc",
-      "version": "2.9.1",
+      "version": "2.10.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^2.0.0",
         "@dfinity/candid": "^2.0.0",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.13.0"
+        "@dfinity/utils": "^2.14.0"
       }
     },
     "packages/nns": {
       "name": "@dfinity/nns",
-      "version": "9.0.0",
+      "version": "9.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
@@ -6825,7 +6825,7 @@
         "@dfinity/candid": "^2.0.0",
         "@dfinity/ledger-icp": "^4",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.13.0"
+        "@dfinity/utils": "^2.14.0"
       }
     },
     "packages/nns-proto": {
@@ -6853,7 +6853,7 @@
     },
     "packages/sns": {
       "name": "@dfinity/sns",
-      "version": "3.7.1",
+      "version": "3.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0"
@@ -6861,9 +6861,9 @@
       "peerDependencies": {
         "@dfinity/agent": "^2.0.0",
         "@dfinity/candid": "^2.0.0",
-        "@dfinity/ledger-icrc": "^2.9",
+        "@dfinity/ledger-icrc": "^2.10",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.13.0"
+        "@dfinity/utils": "^2.14.0"
       }
     },
     "packages/sns/node_modules/@noble/hashes": {
@@ -6880,7 +6880,7 @@
     },
     "packages/utils": {
       "name": "@dfinity/utils",
-      "version": "2.13.2",
+      "version": "2.14.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-js",
-  "version": "71",
+  "version": "72",
   "description": "A collection of library for interfacing with the Internet Computer.",
   "license": "Apache-2.0",
   "workspaces": [

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ckbtc",
-  "version": "3.1.14",
+  "version": "3.2.0",
   "description": "A library for interfacing with ckBTC.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -41,7 +41,7 @@
     "@dfinity/agent": "^2.0.0",
     "@dfinity/candid": "^2.0.0",
     "@dfinity/principal": "^2.0.0",
-    "@dfinity/utils": "^2.13.0"
+    "@dfinity/utils": "^2.14.0"
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0",

--- a/packages/cketh/package.json
+++ b/packages/cketh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/cketh",
-  "version": "3.4.11",
+  "version": "3.4.12",
   "description": "A library for interfacing with ckETH.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -41,6 +41,6 @@
     "@dfinity/agent": "^2.0.0",
     "@dfinity/candid": "^2.0.0",
     "@dfinity/principal": "^2.0.0",
-    "@dfinity/utils": "^2.13.0"
+    "@dfinity/utils": "^2.14.0"
   }
 }

--- a/packages/cmc/package.json
+++ b/packages/cmc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/cmc",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "description": "A library for interfacing with the cycle minting canister.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -39,6 +39,6 @@
     "@dfinity/agent": "^2.0.0",
     "@dfinity/candid": "^2.0.0",
     "@dfinity/principal": "^2.0.0",
-    "@dfinity/utils": "^2.13.0"
+    "@dfinity/utils": "^2.14.0"
   }
 }

--- a/packages/ic-management/package.json
+++ b/packages/ic-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-management",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "A library for interfacing with the IC management canister.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -37,6 +37,6 @@
     "@dfinity/agent": "^2.0.0",
     "@dfinity/candid": "^2.0.0",
     "@dfinity/principal": "^2.0.0",
-    "@dfinity/utils": "^2.13.0"
+    "@dfinity/utils": "^2.14.0"
   }
 }

--- a/packages/ledger-icp/package.json
+++ b/packages/ledger-icp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ledger-icp",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "A library for interfacing with the ICP ledger on the Internet Computer.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -41,6 +41,6 @@
     "@dfinity/agent": "^2.0.0",
     "@dfinity/candid": "^2.0.0",
     "@dfinity/principal": "^2.0.0",
-    "@dfinity/utils": "^2.13.0"
+    "@dfinity/utils": "^2.14.0"
   }
 }

--- a/packages/ledger-icrc/package.json
+++ b/packages/ledger-icrc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ledger-icrc",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "A library for interfacing with ICRC ledgers on the Internet Computer.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -40,6 +40,6 @@
     "@dfinity/agent": "^2.0.0",
     "@dfinity/candid": "^2.0.0",
     "@dfinity/principal": "^2.0.0",
-    "@dfinity/utils": "^2.13.0"
+    "@dfinity/utils": "^2.14.0"
   }
 }

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "A library for interfacing with the Internet Computer's Network Nervous System.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -52,6 +52,6 @@
     "@dfinity/candid": "^2.0.0",
     "@dfinity/ledger-icp": "^4",
     "@dfinity/principal": "^2.0.0",
-    "@dfinity/utils": "^2.13.0"
+    "@dfinity/utils": "^2.14.0"
   }
 }

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/sns",
-  "version": "3.7.1",
+  "version": "3.8.0",
   "description": "A library for interfacing with a Service Nervous System (SNS) project.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
@@ -38,9 +38,9 @@
   "peerDependencies": {
     "@dfinity/agent": "^2.0.0",
     "@dfinity/candid": "^2.0.0",
-    "@dfinity/ledger-icrc": "^2.9",
+    "@dfinity/ledger-icrc": "^2.10",
     "@dfinity/principal": "^2.0.0",
-    "@dfinity/utils": "^2.13.0"
+    "@dfinity/utils": "^2.14.0"
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/utils",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "description": "A collection of utilities and constants for NNS/SNS projects.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",


### PR DESCRIPTION
# Motivation

We want to release a version of before migrating `main` to AgentJS v3.

# Changes

- Bump version and update CHANGELOG to prepare release
