### PR TITLE
refactor: Export util to convert an `IcrcAccount`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Features
 
 - Add the `getMintingAccount` method in the `IcrcLedgerCanister` class.
-- Create util to convert a Candid `Account` object into an `IcrcAccount` type.
+- Create util to convert a Candid `Account` object into an `IcrcAccount` type, and vice versa.
 
 # v78
 

--- a/packages/ledger-icrc/src/converters/converters.spec.ts
+++ b/packages/ledger-icrc/src/converters/converters.spec.ts
@@ -1,14 +1,13 @@
 import { toNullable } from "@dfinity/utils";
 import { mockPrincipal } from "../mocks/ledger.mock";
-import { fromCandidAccount } from "./converters";
+import { fromCandidAccount, toCandidAccount } from "./converters";
 
 describe("converters", () => {
+  const owner = mockPrincipal;
+  const subaccount = new Uint8Array([1, 2, 3]);
+
   describe("fromCandidAccount", () => {
-    const owner = mockPrincipal;
-
     it("should transform a Candid Account to IcrcAccount correctly", () => {
-      const subaccount = new Uint8Array([1, 2, 3]);
-
       expect(
         fromCandidAccount({
           owner,
@@ -28,6 +27,31 @@ describe("converters", () => {
         }),
       ).toStrictEqual({
         owner,
+      });
+    });
+  });
+
+  describe("toCandidAccount", () => {
+    it("should transform an IcrcAccount to a Candid Account correctly", () => {
+      expect(
+        toCandidAccount({
+          owner,
+          subaccount,
+        }),
+      ).toStrictEqual({
+        owner,
+        subaccount: toNullable(subaccount),
+      });
+    });
+
+    it("should handle nullish subaccount", () => {
+      expect(
+        toCandidAccount({
+          owner,
+        }),
+      ).toStrictEqual({
+        owner,
+        subaccount: toNullable(),
       });
     });
   });

--- a/packages/ledger-icrc/src/converters/converters.ts
+++ b/packages/ledger-icrc/src/converters/converters.ts
@@ -1,4 +1,4 @@
-import { fromNullable, nonNullish } from "@dfinity/utils";
+import { fromNullable, nonNullish, toNullable } from "@dfinity/utils";
 import type { Account } from "../../candid/icrc_ledger";
 import type { IcrcAccount } from "../types/ledger.responses";
 
@@ -19,3 +19,17 @@ export const fromCandidAccount = ({
     ...(nonNullish(subaccount) ? { subaccount } : {}),
   };
 };
+
+/**
+ * Converts an IcrcAccount to a Candid Account object, effectively transforming nullish properties into nullable ones.
+ *
+ * @param {IcrcAccount} - The IcrcAccount object to convert.
+ * @return {Account} - The converted Candid Account object.
+ */
+export const toCandidAccount = ({
+  owner,
+  subaccount,
+}: IcrcAccount): Account => ({
+  owner,
+  subaccount: toNullable(subaccount),
+});

--- a/packages/ledger-icrc/src/converters/index.converters.ts
+++ b/packages/ledger-icrc/src/converters/index.converters.ts
@@ -1,17 +1,9 @@
 import { toNullable } from "@dfinity/utils";
-import type {
-  Account,
-  GetAccountTransactionsArgs,
-} from "../../candid/icrc_index";
+import type { GetAccountTransactionsArgs } from "../../candid/icrc_index";
 import type { ListSubaccountsArgs } from "../../candid/icrc_index-ng";
 import type { ListSubaccountsParams } from "../types/index-ng.params";
 import type { GetAccountTransactionsParams } from "../types/index.params";
-import type { IcrcAccount } from "../types/ledger.responses";
-
-const toCandidAccount = ({ owner, subaccount }: IcrcAccount): Account => ({
-  owner,
-  subaccount: toNullable(subaccount),
-});
+import { toCandidAccount } from "./converters";
 
 export const toGetTransactionsArgs = ({
   account,


### PR DESCRIPTION
# Motivation

Suggestion by @peterpeterparker : for consistency, we should move the `toCandidAccount` util in the `converters.ts` module.

# Changes

- Moved `toCandidAccount` util.
- Export it.

# Tests

Added missing tests.

# Todos

- [x] Add entry to changelog (if necessary).
