### PR TITLE
build(core): remove peer exclusion workaround

### DIFF
--- a/scripts/esbuild.mjs
+++ b/scripts/esbuild.mjs
@@ -24,21 +24,11 @@ const rootPeerDependencies = () => {
   return peerDependencies(packageJson);
 };
 
-// TODO: To be removed once all imports have been migrated to `@icp-sdk/core/...`
-const agentJsPeerDependencies = {
-  "@dfinity/agent": "^3",
-  "@dfinity/candid": "^3",
-  "@dfinity/principal": "^3",
-};
-const commonPeerDependencies = {
-  ...rootPeerDependencies(),
-  ...agentJsPeerDependencies,
-};
 const workspacePeerDependencies = peerDependencies(
   join(process.cwd(), "package.json"),
 );
 const externalPeerDependencies = [
-  ...Object.keys(commonPeerDependencies),
+  ...Object.keys(rootPeerDependencies()),
   ...Object.keys(workspacePeerDependencies),
 ];
 


### PR DESCRIPTION
# Motivation

All `import` have been migrated. We shall not need the workaround for the peer dependencies exclusion in the build anymore.

# Changes

- Remove workaround in `esbuild.mjs`

# Tests

The bundle sizes should not change.
