### PR TITLE
build(core): ignore test-utils.ts without prefix

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
   },
   "exclude": [
     "**/src/**/*.test.ts",
-"**/src/**/*test.utils.ts",
+    "**/src/**/*test.utils.ts",
     "**/src/**/*.spec.ts",
     "**/src/**/*.mock.ts",
     "**/vitest.config.ts",


### PR DESCRIPTION
# Motivation

I just noticed the `test-utils.ts` is not ignore by tsc when generating the declarations because the current exclude pattern expected a prefix.
