### PR TITLE
chore(core): extract build.utils scripts

### DIFF
--- a/scripts/build.utils.mjs
+++ b/scripts/build.utils.mjs
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export const SCRIPTS_PATH = __dirname;
+
+/**
+ * Read the package.json of the package (library) to build.
+ */
+export const readPackageJson = (packageJson) => {
+  const json = readFileSync(packageJson, "utf8");
+  const { peerDependencies } = JSON.parse(json);
+  return { peerDependencies: peerDependencies ?? {} };
+};
+
+/**
+ * Root peerDependencies are common external dependencies for all libraries of the mono-repo.
+ */
+export const rootPeerDependencies = () => {
+  const packageJson = join(SCRIPTS_PATH, "../package.json");
+  const { peerDependencies } = readPackageJson(packageJson);
+  return peerDependencies;
+};

--- a/scripts/esbuild.mjs
+++ b/scripts/esbuild.mjs
@@ -3,30 +3,16 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
-  readFileSync,
   statSync,
   writeFileSync,
-} from "fs";
-import { dirname, join } from "path";
-import { fileURLToPath } from "url";
+} from "node:fs";
+import { join } from "node:path";
+import { readPackageJson, rootPeerDependencies } from "./build.utils.mjs";
 
-const peerDependencies = (packageJson) => {
-  const json = readFileSync(packageJson, "utf8");
-  const { peerDependencies } = JSON.parse(json);
-  return peerDependencies ?? {};
-};
-
-/** Root peerDependencies are common external dependencies for all libraries of the mono-repo */
-const rootPeerDependencies = () => {
-  const __filename = fileURLToPath(import.meta.url);
-  const __dirname = dirname(__filename);
-  const packageJson = join(__dirname, "../package.json");
-  return peerDependencies(packageJson);
-};
-
-const workspacePeerDependencies = peerDependencies(
+const { peerDependencies: workspacePeerDependencies } = readPackageJson(
   join(process.cwd(), "package.json"),
 );
+
 const externalPeerDependencies = [
   ...Object.keys(rootPeerDependencies()),
   ...Object.keys(workspacePeerDependencies),


### PR DESCRIPTION
# Motivation

In future scripts we will need few of the existing utilities therefore it's handy to move those to a specitif JavaScript module. 
It also improve readability.

# Changes

- Extract utility to a `build.utils.mjs`
- Rename `pkgJson` to `readPackageJson` and modify return type to object (we will need to add a field in a future PR)
