### PR TITLE
test(canisters): index should throw

### DIFF
--- a/packages/canisters/src/index.spec.ts
+++ b/packages/canisters/src/index.spec.ts
@@ -1,5 +1,7 @@
-describe("TODO temporary", () => {
-  it("should pass", () => {
-    expect(true).toBeTruthy();
+describe("@icp-sdk/canisters", () => {
+  it("should throw loading error", async () => {
+    await expect(import("@icp-sdk/canisters")).rejects.toThrow(
+      "This package has no default entry point. Please import from a subpath.",
+    );
   });
 });


### PR DESCRIPTION
# Motivation

I spotted a leftover, the root test should asset `@icp-sdk/cansisters` root throw an exception if used.