### PR TITLE
chore(core): set version for next release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6590,23 +6590,23 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dfinity/ckbtc": "^4",
-        "@dfinity/cketh": "^4",
-        "@dfinity/cmc": "^6",
-        "@dfinity/ic-management": "^7",
-        "@dfinity/ledger-icp": "^6",
-        "@dfinity/ledger-icrc": "^4",
-        "@dfinity/nns": "^10",
-        "@dfinity/sns": "^4"
+        "@dfinity/ckbtc": "^5",
+        "@dfinity/cketh": "^5",
+        "@dfinity/cmc": "^7",
+        "@dfinity/ic-management": "^8",
+        "@dfinity/ledger-icp": "^7",
+        "@dfinity/ledger-icrc": "^5",
+        "@dfinity/nns": "^11",
+        "@dfinity/sns": "^5"
       },
       "peerDependencies": {
-        "@dfinity/utils": "^3",
+        "@dfinity/utils": "^4",
         "@icp-sdk/core": "^4"
       }
     },
     "packages/ckbtc": {
       "name": "@dfinity/ckbtc",
-      "version": "4.0.6",
+      "version": "5.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
@@ -6614,7 +6614,7 @@
         "bech32": "^2.0.0"
       },
       "peerDependencies": {
-        "@dfinity/utils": "^3",
+        "@dfinity/utils": "^4",
         "@icp-sdk/core": "^4"
       }
     },
@@ -6630,65 +6630,65 @@
     },
     "packages/cketh": {
       "name": "@dfinity/cketh",
-      "version": "4.0.6",
+      "version": "5.0.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/utils": "^3",
+        "@dfinity/utils": "^4",
         "@icp-sdk/core": "^4"
       }
     },
     "packages/cmc": {
       "name": "@dfinity/cmc",
-      "version": "6.0.6",
+      "version": "7.0.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/utils": "^3",
+        "@dfinity/utils": "^4",
         "@icp-sdk/core": "^4"
       }
     },
     "packages/ic-management": {
       "name": "@dfinity/ic-management",
-      "version": "7.1.3",
+      "version": "8.0.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/utils": "^3",
+        "@dfinity/utils": "^4",
         "@icp-sdk/core": "^4"
       }
     },
     "packages/ledger-icp": {
       "name": "@dfinity/ledger-icp",
-      "version": "6.1.2",
+      "version": "7.0.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/utils": "^3",
+        "@dfinity/utils": "^4",
         "@icp-sdk/core": "^4"
       }
     },
     "packages/ledger-icrc": {
       "name": "@dfinity/ledger-icrc",
-      "version": "4.1.2",
+      "version": "5.0.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/utils": "^3",
+        "@dfinity/utils": "^4",
         "@icp-sdk/core": "^4"
       }
     },
     "packages/nns": {
       "name": "@dfinity/nns",
-      "version": "10.4.0",
+      "version": "11.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0"
       },
       "peerDependencies": {
-        "@dfinity/ledger-icp": "^6",
-        "@dfinity/utils": "^3",
+        "@dfinity/ledger-icp": "^7",
+        "@dfinity/utils": "^4",
         "@icp-sdk/core": "^4"
       }
     },
     "packages/nns-proto": {
       "name": "@dfinity/nns-proto",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "google-protobuf": "^3.21.2"
@@ -6699,20 +6699,20 @@
     },
     "packages/sns": {
       "name": "@dfinity/sns",
-      "version": "4.1.2",
+      "version": "5.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0"
       },
       "peerDependencies": {
-        "@dfinity/ledger-icrc": "^4",
-        "@dfinity/utils": "^3",
+        "@dfinity/ledger-icrc": "^5",
+        "@dfinity/utils": "^4",
         "@icp-sdk/core": "^4"
       }
     },
     "packages/utils": {
       "name": "@dfinity/utils",
-      "version": "3.2.0",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@icp-sdk/core": "^4"
@@ -6720,7 +6720,7 @@
     },
     "packages/zod-schemas": {
       "name": "@dfinity/zod-schemas",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@icp-sdk/core": "*",
@@ -7190,14 +7190,14 @@
     "@icp-sdk/canisters": {
       "version": "file:packages/canisters",
       "requires": {
-        "@dfinity/ckbtc": "^4",
-        "@dfinity/cketh": "^4",
-        "@dfinity/cmc": "^6",
-        "@dfinity/ic-management": "^7",
-        "@dfinity/ledger-icp": "^6",
-        "@dfinity/ledger-icrc": "^4",
-        "@dfinity/nns": "^10",
-        "@dfinity/sns": "^4"
+        "@dfinity/ckbtc": "^5",
+        "@dfinity/cketh": "^5",
+        "@dfinity/cmc": "^7",
+        "@dfinity/ic-management": "^8",
+        "@dfinity/ledger-icp": "^7",
+        "@dfinity/ledger-icrc": "^5",
+        "@dfinity/nns": "^11",
+        "@dfinity/sns": "^5"
       }
     },
     "@icp-sdk/core": {

--- a/packages/canisters/package.json
+++ b/packages/canisters/package.json
@@ -97,17 +97,17 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "dependencies": {
-    "@dfinity/ckbtc": "^4",
-    "@dfinity/cketh": "^4",
-    "@dfinity/cmc": "^6",
-    "@dfinity/ic-management": "^7",
-    "@dfinity/ledger-icp": "^6",
-    "@dfinity/ledger-icrc": "^4",
-    "@dfinity/nns": "^10",
-    "@dfinity/sns": "^4"
+    "@dfinity/ckbtc": "^5",
+    "@dfinity/cketh": "^5",
+    "@dfinity/cmc": "^7",
+    "@dfinity/ic-management": "^8",
+    "@dfinity/ledger-icp": "^7",
+    "@dfinity/ledger-icrc": "^5",
+    "@dfinity/nns": "^11",
+    "@dfinity/sns": "^5"
   },
   "peerDependencies": {
-    "@dfinity/utils": "^3",
+    "@dfinity/utils": "^4",
     "@icp-sdk/core": "^4"
   }
 }

--- a/packages/ckbtc/package.json
+++ b/packages/ckbtc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ckbtc",
-  "version": "4.0.6",
+  "version": "5.0.0",
   "description": "A library for interfacing with ckBTC.",
   "license": "Apache-2.0",
   "type": "module",
@@ -51,7 +51,7 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/utils": "^3",
+    "@dfinity/utils": "^4",
     "@icp-sdk/core": "^4"
   },
   "dependencies": {

--- a/packages/cketh/package.json
+++ b/packages/cketh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/cketh",
-  "version": "4.0.6",
+  "version": "5.0.0",
   "description": "A library for interfacing with ckETH.",
   "license": "Apache-2.0",
   "type": "module",
@@ -51,7 +51,7 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/utils": "^3",
+    "@dfinity/utils": "^4",
     "@icp-sdk/core": "^4"
   }
 }

--- a/packages/cmc/package.json
+++ b/packages/cmc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/cmc",
-  "version": "6.0.6",
+  "version": "7.0.0",
   "description": "A library for interfacing with the cycle minting canister.",
   "license": "Apache-2.0",
   "type": "module",
@@ -49,7 +49,7 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/utils": "^3",
+    "@dfinity/utils": "^4",
     "@icp-sdk/core": "^4"
   }
 }

--- a/packages/ic-management/package.json
+++ b/packages/ic-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ic-management",
-  "version": "7.1.3",
+  "version": "8.0.0",
   "description": "A library for interfacing with the IC management canister.",
   "license": "Apache-2.0",
   "type": "module",
@@ -47,7 +47,7 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/utils": "^3",
+    "@dfinity/utils": "^4",
     "@icp-sdk/core": "^4"
   }
 }

--- a/packages/ledger-icp/package.json
+++ b/packages/ledger-icp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ledger-icp",
-  "version": "6.1.2",
+  "version": "7.0.0",
   "description": "A library for interfacing with the ICP ledger on the Internet Computer.",
   "license": "Apache-2.0",
   "type": "module",
@@ -51,7 +51,7 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/utils": "^3",
+    "@dfinity/utils": "^4",
     "@icp-sdk/core": "^4"
   }
 }

--- a/packages/ledger-icrc/package.json
+++ b/packages/ledger-icrc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/ledger-icrc",
-  "version": "4.1.2",
+  "version": "5.0.0",
   "description": "A library for interfacing with ICRC ledgers on the Internet Computer.",
   "license": "Apache-2.0",
   "type": "module",
@@ -50,7 +50,7 @@
   ],
   "homepage": "https://github.com/dfinity/ic-js#readme",
   "peerDependencies": {
-    "@dfinity/utils": "^3",
+    "@dfinity/utils": "^4",
     "@icp-sdk/core": "^4"
   }
 }

--- a/packages/nns-proto/package.json
+++ b/packages/nns-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns-proto",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "The protobuf source used by nns-js to support hardware wallets.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns",
-  "version": "10.4.0",
+  "version": "11.0.0",
   "description": "A library for interfacing with the Internet Computer's Network Nervous System.",
   "license": "Apache-2.0",
   "type": "module",
@@ -60,8 +60,8 @@
     "network-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/ledger-icp": "^6",
-    "@dfinity/utils": "^3",
+    "@dfinity/ledger-icp": "^7",
+    "@dfinity/utils": "^4",
     "@icp-sdk/core": "^4"
   }
 }

--- a/packages/sns/package.json
+++ b/packages/sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/sns",
-  "version": "4.1.2",
+  "version": "5.0.0",
   "description": "A library for interfacing with a Service Nervous System (SNS) project.",
   "license": "Apache-2.0",
   "type": "module",
@@ -49,8 +49,8 @@
     "sns"
   ],
   "peerDependencies": {
-    "@dfinity/ledger-icrc": "^4",
-    "@dfinity/utils": "^3",
+    "@dfinity/ledger-icrc": "^5",
+    "@dfinity/utils": "^4",
     "@icp-sdk/core": "^4"
   },
   "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/utils",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "A collection of utilities and constants for NNS/SNS projects.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/zod-schemas/package.json
+++ b/packages/zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/zod-schemas",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "A collection of reusable Zod schemas and validators for common data patterns in ICP applications",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
# Motivation

While fundamentally there are no features or fixes in the next release, we want to make developers aware there are important changes underneath as the libraries are migrated from `@dfinity/...` to `@icp-sdk/core` peer dependencies.

That is why we bump the libs to a major version.

# Notes

We want to release first a `@next` version and test this in OISY and NNS dapp. We also want to test the new `@icp-sdk/canisters`. That's why this PR does not bump the version number of the root package nor provide the CHANGELOG yet.

# Changes

- Bump major version in legacy dependencies and in utilities.
