### PR TITLE
fix(core): update-version.mjs assertion

### DIFF
--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -34,7 +34,7 @@ const nextVersion = async ({ project, currentVersion }) => {
   ).json();
 
   // The wip version has never been published
-  if (versions[version] === undefined) {
+  if (versions?.[version] === undefined) {
     return version;
   }
 


### PR DESCRIPTION
# Motivation

Of course I had to forget an assertion in #1175. See job https://github.com/dfinity/ic-js/actions/runs/18655886540/job/53184754104

The scripts also needed a small improvement in case there was never ever a version released, which is the case for the new library.

# Changes

- Update check for number of argument in `update-version.mjs`.
- And add support for no versions at all.
