### PR TITLE
chore(canisters): fix publishing scripts

### DIFF
--- a/packages/canisters/.npmignore
+++ b/packages/canisters/.npmignore
@@ -1,4 +1,14 @@
-copy-candid.mjs
+# Git and config files
+.gitignore
+tsconfig.json
+vitest.config.ts
+
+# Build and publish scripts
 copy-ts-declarations.mjs
-pre-pack.mjs
+copy-candid.mjs
+esbuild.mjs
 post-pack.mjs
+pre-pack.mjs
+
+# Sources
+src/

--- a/packages/canisters/package.json
+++ b/packages/canisters/package.json
@@ -54,16 +54,6 @@
       "require": "./sns/index.mjs"
     }
   },
-  "files": [
-    "README.md",
-    "LICENSE",
-    "**/*.js",
-    "**/*.js.map",
-    "**/*.mjs",
-    "**/*.mjs.map",
-    "**/*.d.ts",
-    "**/*.d.ts.map"
-  ],
   "scripts": {
     "clean": "git ls-files --others --ignored --exclude-standard | grep -v \"LICENSE\" | xargs rm -rf",
     "build": "npm run clean && tsc --noEmit && node esbuild.mjs && node copy-candid.mjs && node copy-ts-declarations.mjs",


### PR DESCRIPTION
# Motivation

Despite the rules, the build and publish scripts of `@icp-sdk/canisters` are still published to npm. However, now that we are removing the root `.npmignore` (see #1190), we can change the approach. Instead of telling npm what we want to publish and trying to provide a pattern to exclude some, we can tell npm we want to publish everything except few things.

# Changes

- Remove `files` from package.json
- List ignore files in `.npmignore` of the lib