### PR TITLE
chore(canisters): ignore package.json.backup while publishing

### DIFF
--- a/packages/canisters/.npmignore
+++ b/packages/canisters/.npmignore
@@ -10,5 +10,8 @@ esbuild.mjs
 post-pack.mjs
 pre-pack.mjs
 
+# Temporary files
+package.json.backup
+
 # Sources
 src/


### PR DESCRIPTION
# Motivation

The list of published files looks good now, just forgot to ignore `package.json.backup`.

See https://www.npmjs.com/package/@icp-sdk/canisters/v/0.0.2-next-2025-10-22.2?activeTab=code

# Changes

- Add `package.json.backup` to `.npmignore`