### PR TITLE
chore(build): remove duplicate npm ci in script

### DIFF
--- a/scripts/build-next
+++ b/scripts/build-next
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -eux
 
-npm ci
-
 : Optional tag argument
 TAG=
 


### PR DESCRIPTION
# Motivation

In `build-next`, the script starts with `npm ci`. However, this actually already calls `actions/prepare/action.yml` which itself already did a `npm ci`. Long story short, we do not need this duplication.
