### PR TITLE
chore(core): revert release all legacy and utls libraries

### DIFF
--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -25,11 +25,11 @@ function publish_npm() {
 }
 
 # Tips: libs use by other libs first
-# DFINITY_LIBS=utils,zod-schemas,ledger-icrc,ledger-icp,nns-proto,nns,sns,cmc,ckbtc,cketh,ic-management
+DFINITY_LIBS=utils,zod-schemas,ledger-icrc,ledger-icp,nns-proto,nns,sns,cmc,ckbtc,cketh,ic-management
 
-# for lib in $(echo $DFINITY_LIBS | sed "s/,/ /g"); do
-#   publish_npm "$lib" "dfinity"
-# done
+for lib in $(echo $DFINITY_LIBS | sed "s/,/ /g"); do
+  publish_npm "$lib" "dfinity"
+done
 
 ICP_SDK=canisters
 


### PR DESCRIPTION
# Motivation

In #1189 we commented temporarly the release of the legacy and utils libraries because we didn't had another way to publish the new canisters library. This PR revert that change this way we can proceed with full official release.

# Changes

- Redo releasing all `@dfinity/*` libraries in `publish-npm` script.