### PR TITLE
chore(core): set version v82 for root package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/icp-js-canisters",
-  "version": "80",
+  "version": "82",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/icp-js-canisters",
-      "version": "80",
+      "version": "82",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/utils",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/icp-js-canisters",
-  "version": "80",
+  "version": "82",
   "description": "A collection of library for interfacing with the Internet Computer.",
   "license": "Apache-2.0",
   "workspaces": [


### PR DESCRIPTION
# Motivation

We set the versoin `82` to the root package.json before releasing.

# Notes

It jumps from v80 to v82 because somehow we forgot to set v81 last time we released.
