### PR TITLE
test(canisters): fix "is not a module"

### DIFF
--- a/packages/canisters/src/index.spec.ts
+++ b/packages/canisters/src/index.spec.ts
@@ -1,5 +1,7 @@
 describe("@icp-sdk/canisters", () => {
   it("should throw loading error", async () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
     await expect(import("@icp-sdk/canisters")).rejects.toThrow(
       "This package has no default entry point. Please import from a subpath.",
     );


### PR DESCRIPTION
# Motivation

Fix `npm run test`:

```
❯ npm run test packages/canisters/src/index.spec.ts

packages/canisters/src/index.spec.ts:3:25 - error TS2306: File '/Users/daviddalbusco/projects/dfinity/ic-js/packages/canisters/index.d.ts' is not a module.

3     await expect(import("@icp-sdk/canisters")).rejects.toThrow(
                          ~~~~~~~~~~~~~~~~~~~~


Found 1 error in packages/canisters/src/index.spec.ts:3




```


