### PR TITLE
feat(sns): expose type TransferSnsTreasuryFunds

### DIFF
--- a/packages/sns/src/index.ts
+++ b/packages/sns/src/index.ts
@@ -28,6 +28,7 @@ export type {
   Topic as SnsTopic,
   TopicInfo as SnsTopicInfo,
   VotingRewardsParameters as SnsVotingRewardsParameters,
+  TransferSnsTreasuryFunds,
 } from "./candid/sns_governance";
 export type { CanisterStatusResultV2 as SnsCanisterStatus } from "./candid/sns_root";
 export type {


### PR DESCRIPTION
# Motivation

While migrating to `@icp-sdk/canisters` for testing purposes, I noticed in https://github.com/peterpeterparker/proposals.network/pull/141 that the type `TransferSnsTreasuryFunds` was not exposed while a function that accepts it is.

# Notes

We should really start using the pattern where we expose all the types with a namespace as I do in Juno :)

# Changes

- Expose ts type
