### PR TITLE
ci(core): use build script from root package.json

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Build
-        run: npm run build --workspaces
+        run: npm run build
 
   lint:
     runs-on: ubuntu-24.04
@@ -138,7 +138,7 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Build
-        run: npm run build --workspaces
+        run: npm run build
       - name: Test
         run: npm run test --workspaces
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         uses: ./.github/actions/prepare
 
       - name: Build
-        run: npm run build --workspaces
+        run: npm run build
 
       - name: Publish
         run: ./scripts/publish-npm.sh

--- a/scripts/build-next
+++ b/scripts/build-next
@@ -33,4 +33,4 @@ node ./scripts/update-version.mjs ic-management dfinity $TAG
 node ./scripts/update-version.mjs canisters icp-sdk $TAG
 
 : Now we can build
-npm run build --workspaces
+npm run build


### PR DESCRIPTION
# Motivation

There's no need to add the `--workspaces` flag to the `npm run build` command, as the `build` script in the root `package.json` already does that.
