### PR TITLE
fix(nns): downgrade ledger-icp dependency requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6712,7 +6712,7 @@
         "@noble/hashes": "^1.8.0"
       },
       "peerDependencies": {
-        "@dfinity/ledger-icp": "^8",
+        "@dfinity/ledger-icp": ">=7",
         "@dfinity/utils": "^4",
         "@icp-sdk/core": "^4"
       }

--- a/packages/nns/package.json
+++ b/packages/nns/package.json
@@ -60,7 +60,7 @@
     "network-nervous-system"
   ],
   "peerDependencies": {
-    "@dfinity/ledger-icp": "^8",
+    "@dfinity/ledger-icp": ">=7",
     "@dfinity/utils": "^4",
     "@icp-sdk/core": "^4"
   }


### PR DESCRIPTION
# Motivation

All legacy dependencies were recently shipped as major version with breaking changes in their Candid types except nns which was not affected by those changes and was released as a minor version which pointed to the latest version of the ledger ICP. This however leads to an issue when installing `@icp-sdk/canisters@1.1.1`.

```
❯ npm i @icp-sdk/canisters@1.1.1
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: @dfinity/oisy-wallet@1.8.4
npm error Found: @dfinity/ledger-icp@7.0.1
npm error node_modules/@dfinity/ledger-icp
npm error   peer @dfinity/ledger-icp@"^7" from @icp-sdk/canisters@1.1.1
npm error   node_modules/@icp-sdk/canisters
npm error     @icp-sdk/canisters@"1.1.1" from the root project
npm error
npm error Could not resolve dependency:
npm error peer @dfinity/ledger-icp@"^8" from @dfinity/nns@11.1.3
npm error node_modules/@dfinity/nns
npm error   peer @dfinity/nns@"^11" from @icp-sdk/canisters@1.1.1
npm error   node_modules/@icp-sdk/canisters
npm error     @icp-sdk/canisters@"1.1.1" from the root project
```

The library requires ledger-icp v7 but, the latest minor nns v11.x.y points to v8.

To resolve the problem I propose to accept v7 and above in nns as it is not impacted by the breaking changes - i.e. setting v8 as requirement was not necessary.

# Changes

- Downgrade requirement to ledger-icp >= v7 in nns
