### PR TITLE
chore(canisters): Increase size for `canisters/ICRC` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     {
       "name": "@dfinity/ledger-icrc",
       "path": "./packages/ledger-icrc/dist/index.js",
-      "limit": "5 kB",
+      "limit": "7 kB",
       "gzip": true,
       "ignore": [
         "@dfinity/agent",
@@ -232,7 +232,7 @@
     {
       "name": "@icp-sdk/canisters/ledger/icrc",
       "path": "./packages/canisters/ledger/icrc/index.js",
-      "limit": "5 kB",
+      "limit": "7 kB",
       "gzip": true,
       "ignore": [
         "@dfinity/agent",


### PR DESCRIPTION
# Motivation

Since we are going to include a new class representing the NFT (ICRC-7) ledgers in PR https://github.com/dfinity/icp-js-canisters/pull/1279, we need to increase the size of package ledger-ICRC.
