### PR TITLE
chore(scripts): fix update-agent for missing canisters

### DIFF
--- a/scripts/update-agent
+++ b/scripts/update-agent
@@ -15,7 +15,7 @@ function install_agent() {
   npm i @icp-sdk/core@latest --workspace=packages/"$package" --save-peer
 }
 
-PACKAGES=utils,ckbtc,cketh,cmc,ic-management,ledger-icp,ledger-icrc,nns,sns,zod-schemas
+PACKAGES=utils,ckbtc,cketh,cmc,ic-management,ledger-icp,ledger-icrc,nns,sns,zod-schemas,canisters
 
 # Remove agent-js libraries from all packages first to avoid resolve conflicts between those
 for package in $(echo $PACKAGES | sed "s/,/ /g"); do


### PR DESCRIPTION
# Motivation

The `canisters` package was not listed in `npm run update:agent`. As a result, the update failed because installing a most recent version of the agent conflicted with the version still referenced by canisters:

<img width="1126" height="799" alt="Capture d’écran 2025-11-26 à 06 20 24" src="https://github.com/user-attachments/assets/ad5a6625-db9a-4312-92f5-091613f3f9f5" />

# Changes

- Add `canisters` to the list of package to update
