### PR TITLE
fix(script): import-candid source and destination for assets incorrect

### DIFF
--- a/scripts/import-candid
+++ b/scripts/import-candid
@@ -150,6 +150,6 @@ mkdir -p packages/ic-management/src/candid
 download_did https://raw.githubusercontent.com/dfinity/portal/master/docs/references/_attachments/ic.did "ic-management.did" "ic-management"
 
 mkdir -p packages/canisters/src/declarations/assets
-download_did https://raw.githubusercontent.com/dfinity/sdk/refs/heads/master/src/distributed/assetstorage.did "assets_assetstorage.did" "canisters" "declarations/assets"
+download_did https://raw.githubusercontent.com/dfinity/sdk/master/src/distributed/assetstorage.did "assets_assetstorage.did" "canisters" "src/declarations/assets"
 
 : Fin


### PR DESCRIPTION
# Motivation

1. The weekly `import-candid` job failed today with following error (see this [job](https://github.com/dfinity/icp-js-canisters/actions/runs/19810765727/job/56752823392)). The root cause is the downloading containing references to head.

```
jq: error (at <stdin>:5): Cannot index object with number
Failed to retrieve commit hash for heads/master/src/distributed/assetstorage.did in dfinity/sdk.
```

2. Once fixed, the script would fail at copying to destination with following error. Therefore I also fix this in this PR.

```
Downloading https://raw.githubusercontent.com/dfinity/sdk/master/src/distributed/assetstorage.did -> REPO_ROOT/packages/canisters/declarations/assets/assets_assetstorage.did
./scripts/import-candid: ligne 31: packages/canisters/declarations/assets/assets_assetstorage.did: No such file or directory
```
