### PR TITLE
feat(nns): weekly did update and support for new field return_self_describing_action

### DIFF
--- a/packages/nns/src/candid/genesis_token.did
+++ b/packages/nns/src/candid/genesis_token.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 948d5b9 (2025-11-19 tags: release-2025-11-20_03-21-base) 'rs/nns/gtc/canister/gtc.did' by import-candid
+// Generated from IC repo commit 724ae41 (2025-11-27 tags: release-2025-11-28_03-22-base) 'rs/nns/gtc/canister/gtc.did' by import-candid
 
 type AccountState = record {
   authenticated_principal_id : opt principal;

--- a/packages/nns/src/candid/governance.certified.idl.js
+++ b/packages/nns/src/candid/governance.certified.idl.js
@@ -9,6 +9,7 @@
 export const idlFactory = ({ IDL }) => {
   const ManageNeuronRequest = IDL.Rec();
   const Proposal = IDL.Rec();
+  const SelfDescribingValue = IDL.Rec();
   const NeuronId = IDL.Record({ id: IDL.Nat64 });
   const Followees = IDL.Record({ followees: IDL.Vec(NeuronId) });
   const DateUtc = IDL.Record({
@@ -593,12 +594,28 @@ export const idlFactory = ({ IDL }) => {
     AddOrRemoveNodeProvider: AddOrRemoveNodeProvider,
     Motion: Motion,
   });
+  SelfDescribingValue.fill(
+    IDL.Variant({
+      Int: IDL.Int,
+      Map: IDL.Vec(IDL.Tuple(IDL.Text, SelfDescribingValue)),
+      Nat: IDL.Nat,
+      Blob: IDL.Vec(IDL.Nat8),
+      Text: IDL.Text,
+      Array: IDL.Vec(SelfDescribingValue),
+    }),
+  );
+  const SelfDescribingProposalAction = IDL.Record({
+    type_description: IDL.Opt(IDL.Text),
+    type_name: IDL.Opt(IDL.Text),
+    value: IDL.Opt(SelfDescribingValue),
+  });
   Proposal.fill(
     IDL.Record({
       url: IDL.Text,
       title: IDL.Opt(IDL.Text),
       action: IDL.Opt(Action),
       summary: IDL.Text,
+      self_describing_action: IDL.Opt(SelfDescribingProposalAction),
     }),
   );
   const WaitForQuietState = IDL.Record({
@@ -770,6 +787,9 @@ export const idlFactory = ({ IDL }) => {
     Ok: NodeProvider,
     Err: GovernanceError,
   });
+  const GetPendingProposalsRequest = IDL.Record({
+    return_self_describing_action: IDL.Opt(IDL.Bool),
+  });
   const ProposalInfo = IDL.Record({
     id: IDL.Opt(ProposalId),
     status: IDL.Int32,
@@ -843,6 +863,7 @@ export const idlFactory = ({ IDL }) => {
     node_providers: IDL.Vec(NodeProvider),
   });
   const ListProposalInfoRequest = IDL.Record({
+    return_self_describing_action: IDL.Opt(IDL.Bool),
     include_reward_status: IDL.Vec(IDL.Int32),
     omit_large_fields: IDL.Opt(IDL.Bool),
     before_proposal: IDL.Opt(ProposalId),
@@ -1044,7 +1065,11 @@ export const idlFactory = ({ IDL }) => {
       [],
     ),
     get_node_provider_by_caller: IDL.Func([IDL.Null], [Result_7], []),
-    get_pending_proposals: IDL.Func([], [IDL.Vec(ProposalInfo)], []),
+    get_pending_proposals: IDL.Func(
+      [IDL.Opt(GetPendingProposalsRequest)],
+      [IDL.Vec(ProposalInfo)],
+      [],
+    ),
     get_proposal_info: IDL.Func([IDL.Nat64], [IDL.Opt(ProposalInfo)], []),
     get_restore_aging_summary: IDL.Func([], [RestoreAgingSummary], []),
     list_known_neurons: IDL.Func([], [ListKnownNeuronsResponse], []),
@@ -1088,6 +1113,7 @@ export const idlFactory = ({ IDL }) => {
 
 export const init = ({ IDL }) => {
   const Proposal = IDL.Rec();
+  const SelfDescribingValue = IDL.Rec();
   const NeuronId = IDL.Record({ id: IDL.Nat64 });
   const Followees = IDL.Record({ followees: IDL.Vec(NeuronId) });
   const DateUtc = IDL.Record({
@@ -1672,12 +1698,28 @@ export const init = ({ IDL }) => {
     AddOrRemoveNodeProvider: AddOrRemoveNodeProvider,
     Motion: Motion,
   });
+  SelfDescribingValue.fill(
+    IDL.Variant({
+      Int: IDL.Int,
+      Map: IDL.Vec(IDL.Tuple(IDL.Text, SelfDescribingValue)),
+      Nat: IDL.Nat,
+      Blob: IDL.Vec(IDL.Nat8),
+      Text: IDL.Text,
+      Array: IDL.Vec(SelfDescribingValue),
+    }),
+  );
+  const SelfDescribingProposalAction = IDL.Record({
+    type_description: IDL.Opt(IDL.Text),
+    type_name: IDL.Opt(IDL.Text),
+    value: IDL.Opt(SelfDescribingValue),
+  });
   Proposal.fill(
     IDL.Record({
       url: IDL.Text,
       title: IDL.Opt(IDL.Text),
       action: IDL.Opt(Action),
       summary: IDL.Text,
+      self_describing_action: IDL.Opt(SelfDescribingProposalAction),
     }),
   );
   const WaitForQuietState = IDL.Record({

--- a/packages/nns/src/candid/governance.d.ts
+++ b/packages/nns/src/candid/governance.d.ts
@@ -274,6 +274,9 @@ export interface GetNeuronsFundAuditInfoRequest {
 export interface GetNeuronsFundAuditInfoResponse {
   result: [] | [Result_6];
 }
+export interface GetPendingProposalsRequest {
+  return_self_describing_action: [] | [boolean];
+}
 export interface GlobalTimeOfDay {
   seconds_after_utc_midnight: [] | [bigint];
 }
@@ -502,6 +505,7 @@ export interface ListNodeProvidersResponse {
   node_providers: Array<NodeProvider>;
 }
 export interface ListProposalInfoRequest {
+  return_self_describing_action: [] | [boolean];
   include_reward_status: Int32Array;
   omit_large_fields: [] | [boolean];
   before_proposal: [] | [ProposalId];
@@ -949,6 +953,7 @@ export interface Proposal {
   title: [] | [string];
   action: [] | [Action];
   summary: string;
+  self_describing_action: [] | [SelfDescribingProposalAction];
 }
 export type ProposalActionRequest =
   | { RegisterKnownNeuron: KnownNeuron }
@@ -1076,6 +1081,18 @@ export interface RewardToAccount {
 export interface RewardToNeuron {
   dissolve_delay_seconds: bigint;
 }
+export interface SelfDescribingProposalAction {
+  type_description: [] | [string];
+  type_name: [] | [string];
+  value: [] | [SelfDescribingValue];
+}
+export type SelfDescribingValue =
+  | { Int: bigint }
+  | { Map: Array<[string, SelfDescribingValue]> }
+  | { Nat: bigint }
+  | { Blob: Uint8Array }
+  | { Text: string }
+  | { Array: Array<SelfDescribingValue> };
 export interface SetDefaultFollowees {
   default_followees: Array<[number, Followees]>;
 }
@@ -1302,7 +1319,10 @@ export interface _SERVICE {
     GetNeuronsFundAuditInfoResponse
   >;
   get_node_provider_by_caller: ActorMethod<[null], Result_7>;
-  get_pending_proposals: ActorMethod<[], Array<ProposalInfo>>;
+  get_pending_proposals: ActorMethod<
+    [[] | [GetPendingProposalsRequest]],
+    Array<ProposalInfo>
+  >;
   get_proposal_info: ActorMethod<[bigint], [] | [ProposalInfo]>;
   get_restore_aging_summary: ActorMethod<[], RestoreAgingSummary>;
   list_known_neurons: ActorMethod<[], ListKnownNeuronsResponse>;

--- a/packages/nns/src/candid/governance.did
+++ b/packages/nns/src/candid/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 948d5b9 (2025-11-19 tags: release-2025-11-20_03-21-base) 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 724ae41 (2025-11-27 tags: release-2025-11-28_03-22-base) 'rs/nns/governance/canister/governance.did' by import-candid
 
 type AccountIdentifier = record {
   hash : blob;
@@ -527,6 +527,7 @@ type ListProposalInfoRequest = record {
   exclude_topic : vec int32;
   include_all_manage_neuron_proposals : opt bool;
   include_status : vec int32;
+  return_self_describing_action : opt bool;
 };
 
 type ListProposalInfoResponse = record {
@@ -1009,6 +1010,7 @@ type Proposal = record {
   title : opt text;
   action : opt Action;
   summary : text;
+  self_describing_action : opt SelfDescribingProposalAction;
 };
 
 type ProposalActionRequest = variant {
@@ -1428,6 +1430,25 @@ type Vote = variant {
   No;
 };
 
+type SelfDescribingProposalAction = record {
+  type_name : opt text;
+  type_description : opt text;
+  value : opt SelfDescribingValue;
+};
+
+type SelfDescribingValue = variant {
+  Blob : blob;
+  Text : text;
+  Nat : nat;
+  Int : int;
+  Array : vec SelfDescribingValue;
+  Map : vec record { text; SelfDescribingValue };
+};
+
+type GetPendingProposalsRequest = record {
+  return_self_describing_action : opt bool;
+}
+
 service : (Governance) -> {
   claim_gtc_neurons : (principal, vec NeuronId) -> (Result);
   claim_or_refresh_neuron_from_account : (ClaimOrRefreshNeuronFromAccount) -> (
@@ -1455,7 +1476,7 @@ service : (Governance) -> {
       GetNeuronsFundAuditInfoResponse,
     ) query;
   get_node_provider_by_caller : (null) -> (Result_7) query;
-  get_pending_proposals : () -> (vec ProposalInfo) query;
+  get_pending_proposals : (opt GetPendingProposalsRequest) -> (vec ProposalInfo) query;
   get_proposal_info : (nat64) -> (opt ProposalInfo) query;
   get_restore_aging_summary : () -> (RestoreAgingSummary) query;
   list_known_neurons : () -> (ListKnownNeuronsResponse) query;

--- a/packages/nns/src/candid/governance.idl.js
+++ b/packages/nns/src/candid/governance.idl.js
@@ -9,6 +9,7 @@
 export const idlFactory = ({ IDL }) => {
   const ManageNeuronRequest = IDL.Rec();
   const Proposal = IDL.Rec();
+  const SelfDescribingValue = IDL.Rec();
   const NeuronId = IDL.Record({ id: IDL.Nat64 });
   const Followees = IDL.Record({ followees: IDL.Vec(NeuronId) });
   const DateUtc = IDL.Record({
@@ -593,12 +594,28 @@ export const idlFactory = ({ IDL }) => {
     AddOrRemoveNodeProvider: AddOrRemoveNodeProvider,
     Motion: Motion,
   });
+  SelfDescribingValue.fill(
+    IDL.Variant({
+      Int: IDL.Int,
+      Map: IDL.Vec(IDL.Tuple(IDL.Text, SelfDescribingValue)),
+      Nat: IDL.Nat,
+      Blob: IDL.Vec(IDL.Nat8),
+      Text: IDL.Text,
+      Array: IDL.Vec(SelfDescribingValue),
+    }),
+  );
+  const SelfDescribingProposalAction = IDL.Record({
+    type_description: IDL.Opt(IDL.Text),
+    type_name: IDL.Opt(IDL.Text),
+    value: IDL.Opt(SelfDescribingValue),
+  });
   Proposal.fill(
     IDL.Record({
       url: IDL.Text,
       title: IDL.Opt(IDL.Text),
       action: IDL.Opt(Action),
       summary: IDL.Text,
+      self_describing_action: IDL.Opt(SelfDescribingProposalAction),
     }),
   );
   const WaitForQuietState = IDL.Record({
@@ -770,6 +787,9 @@ export const idlFactory = ({ IDL }) => {
     Ok: NodeProvider,
     Err: GovernanceError,
   });
+  const GetPendingProposalsRequest = IDL.Record({
+    return_self_describing_action: IDL.Opt(IDL.Bool),
+  });
   const ProposalInfo = IDL.Record({
     id: IDL.Opt(ProposalId),
     status: IDL.Int32,
@@ -843,6 +863,7 @@ export const idlFactory = ({ IDL }) => {
     node_providers: IDL.Vec(NodeProvider),
   });
   const ListProposalInfoRequest = IDL.Record({
+    return_self_describing_action: IDL.Opt(IDL.Bool),
     include_reward_status: IDL.Vec(IDL.Int32),
     omit_large_fields: IDL.Opt(IDL.Bool),
     before_proposal: IDL.Opt(ProposalId),
@@ -1048,7 +1069,11 @@ export const idlFactory = ({ IDL }) => {
       ["query"],
     ),
     get_node_provider_by_caller: IDL.Func([IDL.Null], [Result_7], ["query"]),
-    get_pending_proposals: IDL.Func([], [IDL.Vec(ProposalInfo)], ["query"]),
+    get_pending_proposals: IDL.Func(
+      [IDL.Opt(GetPendingProposalsRequest)],
+      [IDL.Vec(ProposalInfo)],
+      ["query"],
+    ),
     get_proposal_info: IDL.Func(
       [IDL.Nat64],
       [IDL.Opt(ProposalInfo)],
@@ -1096,6 +1121,7 @@ export const idlFactory = ({ IDL }) => {
 
 export const init = ({ IDL }) => {
   const Proposal = IDL.Rec();
+  const SelfDescribingValue = IDL.Rec();
   const NeuronId = IDL.Record({ id: IDL.Nat64 });
   const Followees = IDL.Record({ followees: IDL.Vec(NeuronId) });
   const DateUtc = IDL.Record({
@@ -1680,12 +1706,28 @@ export const init = ({ IDL }) => {
     AddOrRemoveNodeProvider: AddOrRemoveNodeProvider,
     Motion: Motion,
   });
+  SelfDescribingValue.fill(
+    IDL.Variant({
+      Int: IDL.Int,
+      Map: IDL.Vec(IDL.Tuple(IDL.Text, SelfDescribingValue)),
+      Nat: IDL.Nat,
+      Blob: IDL.Vec(IDL.Nat8),
+      Text: IDL.Text,
+      Array: IDL.Vec(SelfDescribingValue),
+    }),
+  );
+  const SelfDescribingProposalAction = IDL.Record({
+    type_description: IDL.Opt(IDL.Text),
+    type_name: IDL.Opt(IDL.Text),
+    value: IDL.Opt(SelfDescribingValue),
+  });
   Proposal.fill(
     IDL.Record({
       url: IDL.Text,
       title: IDL.Opt(IDL.Text),
       action: IDL.Opt(Action),
       summary: IDL.Text,
+      self_describing_action: IDL.Opt(SelfDescribingProposalAction),
     }),
   );
   const WaitForQuietState = IDL.Record({

--- a/packages/nns/src/candid/governance_test.certified.idl.js
+++ b/packages/nns/src/candid/governance_test.certified.idl.js
@@ -9,6 +9,7 @@
 export const idlFactory = ({ IDL }) => {
   const ManageNeuronRequest = IDL.Rec();
   const Proposal = IDL.Rec();
+  const SelfDescribingValue = IDL.Rec();
   const NeuronId = IDL.Record({ id: IDL.Nat64 });
   const Followees = IDL.Record({ followees: IDL.Vec(NeuronId) });
   const DateUtc = IDL.Record({
@@ -593,12 +594,28 @@ export const idlFactory = ({ IDL }) => {
     AddOrRemoveNodeProvider: AddOrRemoveNodeProvider,
     Motion: Motion,
   });
+  SelfDescribingValue.fill(
+    IDL.Variant({
+      Int: IDL.Int,
+      Map: IDL.Vec(IDL.Tuple(IDL.Text, SelfDescribingValue)),
+      Nat: IDL.Nat,
+      Blob: IDL.Vec(IDL.Nat8),
+      Text: IDL.Text,
+      Array: IDL.Vec(SelfDescribingValue),
+    }),
+  );
+  const SelfDescribingProposalAction = IDL.Record({
+    type_description: IDL.Opt(IDL.Text),
+    type_name: IDL.Opt(IDL.Text),
+    value: IDL.Opt(SelfDescribingValue),
+  });
   Proposal.fill(
     IDL.Record({
       url: IDL.Text,
       title: IDL.Opt(IDL.Text),
       action: IDL.Opt(Action),
       summary: IDL.Text,
+      self_describing_action: IDL.Opt(SelfDescribingProposalAction),
     }),
   );
   const WaitForQuietState = IDL.Record({
@@ -770,6 +787,9 @@ export const idlFactory = ({ IDL }) => {
     Ok: NodeProvider,
     Err: GovernanceError,
   });
+  const GetPendingProposalsRequest = IDL.Record({
+    return_self_describing_action: IDL.Opt(IDL.Bool),
+  });
   const ProposalInfo = IDL.Record({
     id: IDL.Opt(ProposalId),
     status: IDL.Int32,
@@ -843,6 +863,7 @@ export const idlFactory = ({ IDL }) => {
     node_providers: IDL.Vec(NodeProvider),
   });
   const ListProposalInfoRequest = IDL.Record({
+    return_self_describing_action: IDL.Opt(IDL.Bool),
     include_reward_status: IDL.Vec(IDL.Int32),
     omit_large_fields: IDL.Opt(IDL.Bool),
     before_proposal: IDL.Opt(ProposalId),
@@ -1044,7 +1065,11 @@ export const idlFactory = ({ IDL }) => {
       [],
     ),
     get_node_provider_by_caller: IDL.Func([IDL.Null], [Result_7], []),
-    get_pending_proposals: IDL.Func([], [IDL.Vec(ProposalInfo)], []),
+    get_pending_proposals: IDL.Func(
+      [IDL.Opt(GetPendingProposalsRequest)],
+      [IDL.Vec(ProposalInfo)],
+      [],
+    ),
     get_proposal_info: IDL.Func([IDL.Nat64], [IDL.Opt(ProposalInfo)], []),
     get_restore_aging_summary: IDL.Func([], [RestoreAgingSummary], []),
     list_known_neurons: IDL.Func([], [ListKnownNeuronsResponse], []),
@@ -1089,6 +1114,7 @@ export const idlFactory = ({ IDL }) => {
 
 export const init = ({ IDL }) => {
   const Proposal = IDL.Rec();
+  const SelfDescribingValue = IDL.Rec();
   const NeuronId = IDL.Record({ id: IDL.Nat64 });
   const Followees = IDL.Record({ followees: IDL.Vec(NeuronId) });
   const DateUtc = IDL.Record({
@@ -1673,12 +1699,28 @@ export const init = ({ IDL }) => {
     AddOrRemoveNodeProvider: AddOrRemoveNodeProvider,
     Motion: Motion,
   });
+  SelfDescribingValue.fill(
+    IDL.Variant({
+      Int: IDL.Int,
+      Map: IDL.Vec(IDL.Tuple(IDL.Text, SelfDescribingValue)),
+      Nat: IDL.Nat,
+      Blob: IDL.Vec(IDL.Nat8),
+      Text: IDL.Text,
+      Array: IDL.Vec(SelfDescribingValue),
+    }),
+  );
+  const SelfDescribingProposalAction = IDL.Record({
+    type_description: IDL.Opt(IDL.Text),
+    type_name: IDL.Opt(IDL.Text),
+    value: IDL.Opt(SelfDescribingValue),
+  });
   Proposal.fill(
     IDL.Record({
       url: IDL.Text,
       title: IDL.Opt(IDL.Text),
       action: IDL.Opt(Action),
       summary: IDL.Text,
+      self_describing_action: IDL.Opt(SelfDescribingProposalAction),
     }),
   );
   const WaitForQuietState = IDL.Record({

--- a/packages/nns/src/candid/governance_test.d.ts
+++ b/packages/nns/src/candid/governance_test.d.ts
@@ -274,6 +274,9 @@ export interface GetNeuronsFundAuditInfoRequest {
 export interface GetNeuronsFundAuditInfoResponse {
   result: [] | [Result_6];
 }
+export interface GetPendingProposalsRequest {
+  return_self_describing_action: [] | [boolean];
+}
 export interface GlobalTimeOfDay {
   seconds_after_utc_midnight: [] | [bigint];
 }
@@ -502,6 +505,7 @@ export interface ListNodeProvidersResponse {
   node_providers: Array<NodeProvider>;
 }
 export interface ListProposalInfoRequest {
+  return_self_describing_action: [] | [boolean];
   include_reward_status: Int32Array;
   omit_large_fields: [] | [boolean];
   before_proposal: [] | [ProposalId];
@@ -949,6 +953,7 @@ export interface Proposal {
   title: [] | [string];
   action: [] | [Action];
   summary: string;
+  self_describing_action: [] | [SelfDescribingProposalAction];
 }
 export type ProposalActionRequest =
   | { RegisterKnownNeuron: KnownNeuron }
@@ -1076,6 +1081,18 @@ export interface RewardToAccount {
 export interface RewardToNeuron {
   dissolve_delay_seconds: bigint;
 }
+export interface SelfDescribingProposalAction {
+  type_description: [] | [string];
+  type_name: [] | [string];
+  value: [] | [SelfDescribingValue];
+}
+export type SelfDescribingValue =
+  | { Int: bigint }
+  | { Map: Array<[string, SelfDescribingValue]> }
+  | { Nat: bigint }
+  | { Blob: Uint8Array }
+  | { Text: string }
+  | { Array: Array<SelfDescribingValue> };
 export interface SetDefaultFollowees {
   default_followees: Array<[number, Followees]>;
 }
@@ -1302,7 +1319,10 @@ export interface _SERVICE {
     GetNeuronsFundAuditInfoResponse
   >;
   get_node_provider_by_caller: ActorMethod<[null], Result_7>;
-  get_pending_proposals: ActorMethod<[], Array<ProposalInfo>>;
+  get_pending_proposals: ActorMethod<
+    [[] | [GetPendingProposalsRequest]],
+    Array<ProposalInfo>
+  >;
   get_proposal_info: ActorMethod<[bigint], [] | [ProposalInfo]>;
   get_restore_aging_summary: ActorMethod<[], RestoreAgingSummary>;
   list_known_neurons: ActorMethod<[], ListKnownNeuronsResponse>;

--- a/packages/nns/src/candid/governance_test.did
+++ b/packages/nns/src/candid/governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 5e10dc3 (2025-11-24) 'packages/nns/src/candid/governance_test.did.tmp' by import-candid
+// Generated from IC repo commit c49fb87 (2025-12-02) 'packages/nns/src/candid/governance_test.did.tmp' by import-candid
 
 type AccountIdentifier = record {
   hash : blob;
@@ -527,6 +527,7 @@ type ListProposalInfoRequest = record {
   exclude_topic : vec int32;
   include_all_manage_neuron_proposals : opt bool;
   include_status : vec int32;
+  return_self_describing_action : opt bool;
 };
 
 type ListProposalInfoResponse = record {
@@ -1009,6 +1010,7 @@ type Proposal = record {
   title : opt text;
   action : opt Action;
   summary : text;
+  self_describing_action : opt SelfDescribingProposalAction;
 };
 
 type ProposalActionRequest = variant {
@@ -1428,6 +1430,25 @@ type Vote = variant {
   No;
 };
 
+type SelfDescribingProposalAction = record {
+  type_name : opt text;
+  type_description : opt text;
+  value : opt SelfDescribingValue;
+};
+
+type SelfDescribingValue = variant {
+  Blob : blob;
+  Text : text;
+  Nat : nat;
+  Int : int;
+  Array : vec SelfDescribingValue;
+  Map : vec record { text; SelfDescribingValue };
+};
+
+type GetPendingProposalsRequest = record {
+  return_self_describing_action : opt bool;
+}
+
 service : (Governance) -> {
   claim_gtc_neurons : (principal, vec NeuronId) -> (Result);
   claim_or_refresh_neuron_from_account : (ClaimOrRefreshNeuronFromAccount) -> (
@@ -1455,7 +1476,7 @@ service : (Governance) -> {
       GetNeuronsFundAuditInfoResponse,
     ) query;
   get_node_provider_by_caller : (null) -> (Result_7) query;
-  get_pending_proposals : () -> (vec ProposalInfo) query;
+  get_pending_proposals : (opt GetPendingProposalsRequest) -> (vec ProposalInfo) query;
   get_proposal_info : (nat64) -> (opt ProposalInfo) query;
   get_restore_aging_summary : () -> (RestoreAgingSummary) query;
   list_known_neurons : () -> (ListKnownNeuronsResponse) query;

--- a/packages/nns/src/candid/governance_test.idl.js
+++ b/packages/nns/src/candid/governance_test.idl.js
@@ -9,6 +9,7 @@
 export const idlFactory = ({ IDL }) => {
   const ManageNeuronRequest = IDL.Rec();
   const Proposal = IDL.Rec();
+  const SelfDescribingValue = IDL.Rec();
   const NeuronId = IDL.Record({ id: IDL.Nat64 });
   const Followees = IDL.Record({ followees: IDL.Vec(NeuronId) });
   const DateUtc = IDL.Record({
@@ -593,12 +594,28 @@ export const idlFactory = ({ IDL }) => {
     AddOrRemoveNodeProvider: AddOrRemoveNodeProvider,
     Motion: Motion,
   });
+  SelfDescribingValue.fill(
+    IDL.Variant({
+      Int: IDL.Int,
+      Map: IDL.Vec(IDL.Tuple(IDL.Text, SelfDescribingValue)),
+      Nat: IDL.Nat,
+      Blob: IDL.Vec(IDL.Nat8),
+      Text: IDL.Text,
+      Array: IDL.Vec(SelfDescribingValue),
+    }),
+  );
+  const SelfDescribingProposalAction = IDL.Record({
+    type_description: IDL.Opt(IDL.Text),
+    type_name: IDL.Opt(IDL.Text),
+    value: IDL.Opt(SelfDescribingValue),
+  });
   Proposal.fill(
     IDL.Record({
       url: IDL.Text,
       title: IDL.Opt(IDL.Text),
       action: IDL.Opt(Action),
       summary: IDL.Text,
+      self_describing_action: IDL.Opt(SelfDescribingProposalAction),
     }),
   );
   const WaitForQuietState = IDL.Record({
@@ -770,6 +787,9 @@ export const idlFactory = ({ IDL }) => {
     Ok: NodeProvider,
     Err: GovernanceError,
   });
+  const GetPendingProposalsRequest = IDL.Record({
+    return_self_describing_action: IDL.Opt(IDL.Bool),
+  });
   const ProposalInfo = IDL.Record({
     id: IDL.Opt(ProposalId),
     status: IDL.Int32,
@@ -843,6 +863,7 @@ export const idlFactory = ({ IDL }) => {
     node_providers: IDL.Vec(NodeProvider),
   });
   const ListProposalInfoRequest = IDL.Record({
+    return_self_describing_action: IDL.Opt(IDL.Bool),
     include_reward_status: IDL.Vec(IDL.Int32),
     omit_large_fields: IDL.Opt(IDL.Bool),
     before_proposal: IDL.Opt(ProposalId),
@@ -1048,7 +1069,11 @@ export const idlFactory = ({ IDL }) => {
       ["query"],
     ),
     get_node_provider_by_caller: IDL.Func([IDL.Null], [Result_7], ["query"]),
-    get_pending_proposals: IDL.Func([], [IDL.Vec(ProposalInfo)], ["query"]),
+    get_pending_proposals: IDL.Func(
+      [IDL.Opt(GetPendingProposalsRequest)],
+      [IDL.Vec(ProposalInfo)],
+      ["query"],
+    ),
     get_proposal_info: IDL.Func(
       [IDL.Nat64],
       [IDL.Opt(ProposalInfo)],
@@ -1097,6 +1122,7 @@ export const idlFactory = ({ IDL }) => {
 
 export const init = ({ IDL }) => {
   const Proposal = IDL.Rec();
+  const SelfDescribingValue = IDL.Rec();
   const NeuronId = IDL.Record({ id: IDL.Nat64 });
   const Followees = IDL.Record({ followees: IDL.Vec(NeuronId) });
   const DateUtc = IDL.Record({
@@ -1681,12 +1707,28 @@ export const init = ({ IDL }) => {
     AddOrRemoveNodeProvider: AddOrRemoveNodeProvider,
     Motion: Motion,
   });
+  SelfDescribingValue.fill(
+    IDL.Variant({
+      Int: IDL.Int,
+      Map: IDL.Vec(IDL.Tuple(IDL.Text, SelfDescribingValue)),
+      Nat: IDL.Nat,
+      Blob: IDL.Vec(IDL.Nat8),
+      Text: IDL.Text,
+      Array: IDL.Vec(SelfDescribingValue),
+    }),
+  );
+  const SelfDescribingProposalAction = IDL.Record({
+    type_description: IDL.Opt(IDL.Text),
+    type_name: IDL.Opt(IDL.Text),
+    value: IDL.Opt(SelfDescribingValue),
+  });
   Proposal.fill(
     IDL.Record({
       url: IDL.Text,
       title: IDL.Opt(IDL.Text),
       action: IDL.Opt(Action),
       summary: IDL.Text,
+      self_describing_action: IDL.Opt(SelfDescribingProposalAction),
     }),
   );
   const WaitForQuietState = IDL.Record({

--- a/packages/nns/src/candid/sns_wasm.did
+++ b/packages/nns/src/candid/sns_wasm.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 948d5b9 (2025-11-19 tags: release-2025-11-20_03-21-base) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
+// Generated from IC repo commit 724ae41 (2025-11-27 tags: release-2025-11-28_03-22-base) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
 
 type AddWasmRequest = record {
   hash : blob;

--- a/packages/nns/src/canisters/governance/request.converters.ts
+++ b/packages/nns/src/canisters/governance/request.converters.ts
@@ -1112,6 +1112,7 @@ export const fromListProposalsRequest = ({
   limit,
   includeAllManageNeuronProposals,
   omitLargeFields,
+  returnSelfDescribingAction,
 }: ListProposalsRequest): RawListProposalInfo => ({
   include_reward_status: Int32Array.from(includeRewardStatus),
   before_proposal: beforeProposal ? [fromProposalId(beforeProposal)] : [],
@@ -1123,6 +1124,7 @@ export const fromListProposalsRequest = ({
       : [],
   include_status: Int32Array.from(includeStatus),
   omit_large_fields: toNullable(omitLargeFields),
+  return_self_describing_action: toNullable(returnSelfDescribingAction),
 });
 
 /* Protobuf is not supported yet

--- a/packages/nns/src/governance.canister.spec.ts
+++ b/packages/nns/src/governance.canister.spec.ts
@@ -769,6 +769,7 @@ describe("GovernanceCanister", () => {
         include_all_manage_neuron_proposals: [false],
         include_status: new Int32Array(),
         omit_large_fields: [],
+        return_self_describing_action: [],
       });
       expect(proposals).toHaveLength(1);
     });
@@ -806,6 +807,45 @@ describe("GovernanceCanister", () => {
         include_all_manage_neuron_proposals: [false],
         include_status: new Int32Array(),
         omit_large_fields: [true],
+        return_self_describing_action: [],
+      });
+      expect(proposals).toHaveLength(1);
+    });
+
+    it("list user proposals supports optional returnSelfDescribingAction", async () => {
+      const service = mock<ActorSubclass<GovernanceService>>();
+      service.list_proposals.mockResolvedValue({
+        proposal_info: [rawProposal],
+      });
+
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+        serviceOverride: service,
+      });
+      const limit = 2;
+      const { proposals } = await governance.listProposals({
+        certified: true,
+        request: {
+          limit,
+          beforeProposal: undefined,
+          includeRewardStatus: [],
+          includeAllManageNeuronProposals: false,
+          excludeTopic: [],
+          includeStatus: [],
+          returnSelfDescribingAction: true,
+        },
+      });
+
+      expect(service.list_proposals).toHaveBeenCalled();
+      expect(service.list_proposals).toHaveBeenCalledWith({
+        limit,
+        include_reward_status: new Int32Array(),
+        before_proposal: [],
+        exclude_topic: new Int32Array(),
+        include_all_manage_neuron_proposals: [false],
+        include_status: new Int32Array(),
+        omit_large_fields: [],
+        return_self_describing_action: [true],
       });
       expect(proposals).toHaveLength(1);
     });

--- a/packages/nns/src/types/governance_converters.ts
+++ b/packages/nns/src/types/governance_converters.ts
@@ -256,6 +256,9 @@ export interface ListProposalsRequest {
   // is useful to improve download times and to ensure that the response to the
   // request doesn't exceed the message size limit.
   omitLargeFields?: boolean;
+
+  // Whether to include self-describing proposal actions in the response.
+  returnSelfDescribingAction?: boolean;
 }
 export interface ListProposalsResponse {
   proposals: Array<ProposalInfo>;


### PR DESCRIPTION
# Motivation

There is a "breaking change" / new field added in the parameters of the Governance `list_proposals` (see #1307). Therefore, we need to add support for it.

# Changes

- Add support for new field `return_self_describing_action` (basically same implementation as the existing support of `omit_large_fields`)
- Cherry pick DID updates from #1307