### PR TITLE
feat(assets): rename AssetsActor for AssetsService

### DIFF
--- a/packages/canisters/src/declarations/_factory.ts
+++ b/packages/canisters/src/declarations/_factory.ts
@@ -1,5 +1,5 @@
 import { idlFactory as idlFactoryAssets } from "./assets/assets_assetstorage.idl";
 
-import type { _SERVICE as AssetsActor } from "./assets/assets_assetstorage";
+import type { _SERVICE as AssetsService } from "./assets/assets_assetstorage";
 
-export { idlFactoryAssets, type AssetsActor };
+export { idlFactoryAssets, type AssetsService };


### PR DESCRIPTION
# Motivation

We decided with @AntonioVentilii to stick to a `Service` suffix - as it used to be used in the actors of the legacy library. Therefore we rename `AssetsActor` to `AssetsService`
