### PR TITLE
feat(canisters): use did namespace for ic-mgmt

### DIFF
--- a/packages/canisters/src/ic-management/ic-management.canister.spec.ts
+++ b/packages/canisters/src/ic-management/ic-management.canister.spec.ts
@@ -6,16 +6,7 @@ import {
 } from "@dfinity/utils";
 import type { ActorSubclass, HttpAgent } from "@icp-sdk/core/agent";
 import { mock } from "vitest-mock-extended";
-import type {
-  canister_install_mode,
-  chunk_hash,
-  _SERVICE as IcManagementService,
-  list_canister_snapshots_result,
-  read_canister_snapshot_data_response,
-  read_canister_snapshot_metadata_response,
-  take_canister_snapshot_result,
-  upload_canister_snapshot_metadata_response,
-} from "../declarations/ic-management/ic-management";
+import type { IcManagementDid, IcManagementService } from "../declarations";
 import { ICManagementCanister } from "./ic-management.canister";
 import {
   mappedMockCanisterSettings,
@@ -48,7 +39,7 @@ import { decodeSnapshotId } from "./utils/ic-management.utils";
 describe("ICManagementCanister", () => {
   const mockAgent: HttpAgent = mock<HttpAgent>();
 
-  const mockInstallCodeModes: canister_install_mode[] = [
+  const mockInstallCodeModes: IcManagementDid.canister_install_mode[] = [
     { install: null },
     { reinstall: null },
     { upgrade: [] },
@@ -606,7 +597,7 @@ describe("ICManagementCanister", () => {
     };
 
     it("returns hash when success", async () => {
-      const response: chunk_hash = {
+      const response: IcManagementDid.chunk_hash = {
         hash: arrayOfNumberToUint8Array([1, 2, 3, 4]),
       };
       const service = mock<IcManagementService>();
@@ -673,7 +664,7 @@ describe("ICManagementCanister", () => {
     };
 
     it("returns list of hash when success", async () => {
-      const response: chunk_hash[] = [
+      const response: IcManagementDid.chunk_hash[] = [
         { hash: arrayOfNumberToUint8Array([1, 2, 3, 4]) },
         { hash: arrayOfNumberToUint8Array([5, 6, 7]) },
         { hash: arrayOfNumberToUint8Array([8, 9, 10]) },
@@ -878,7 +869,7 @@ describe("ICManagementCanister", () => {
   });
 
   describe("takeCanisterSnapshot", () => {
-    const mockResponse: take_canister_snapshot_result = {
+    const mockResponse: IcManagementDid.take_canister_snapshot_result = {
       id: Uint8Array.from([1, 2, 3, 4]),
       total_size: BigInt(5000),
       taken_at_timestamp: BigInt(1680000000000),
@@ -976,7 +967,8 @@ describe("ICManagementCanister", () => {
       },
     ];
 
-    const mockResponse: list_canister_snapshots_result = mockSnapshots;
+    const mockResponse: IcManagementDid.list_canister_snapshots_result =
+      mockSnapshots;
 
     it("should return a list of snapshots for a canister", async () => {
       const service = mock<IcManagementService>();
@@ -1164,19 +1156,20 @@ describe("ICManagementCanister", () => {
   });
 
   describe("readCanisterSnapshotMetadata", () => {
-    const mockResponse: read_canister_snapshot_metadata_response = {
-      globals: [{ i32: 5 }, { i64: 10n }],
-      certified_data: new Uint8Array([7, 8, 9]),
-      global_timer: [],
-      on_low_wasm_memory_hook_status: [],
-      wasm_module_size: 10000n,
-      stable_memory_size: 20000n,
-      wasm_memory_size: 30000n,
-      canister_version: 123n,
-      source: { metadata_upload: { hello: "world test" } },
-      wasm_chunk_store: [{ hash: new Uint8Array([9, 9, 9]) }],
-      taken_at_timestamp: 123456789n,
-    };
+    const mockResponse: IcManagementDid.read_canister_snapshot_metadata_response =
+      {
+        globals: [{ i32: 5 }, { i64: 10n }],
+        certified_data: new Uint8Array([7, 8, 9]),
+        global_timer: [],
+        on_low_wasm_memory_hook_status: [],
+        wasm_module_size: 10000n,
+        stable_memory_size: 20000n,
+        wasm_memory_size: 30000n,
+        canister_version: 123n,
+        source: { metadata_upload: { hello: "world test" } },
+        wasm_chunk_store: [{ hash: new Uint8Array([9, 9, 9]) }],
+        taken_at_timestamp: 123456789n,
+      };
 
     it("should call read_canister_snapshot_metadata with Uint8Array snapshotId", async () => {
       const service = mock<IcManagementService>();
@@ -1246,7 +1239,7 @@ describe("ICManagementCanister", () => {
   });
 
   describe("readCanisterSnapshotData", () => {
-    const mockResponse: read_canister_snapshot_data_response = {
+    const mockResponse: IcManagementDid.read_canister_snapshot_data_response = {
       chunk: arrayOfNumberToUint8Array([4, 5, 6, 7, 7]),
     };
 
@@ -1322,9 +1315,10 @@ describe("ICManagementCanister", () => {
   });
 
   describe("uploadCanisterSnapshotMetadata", () => {
-    const mockResponse: upload_canister_snapshot_metadata_response = {
-      snapshot_id: Uint8Array.from([1, 2, 4, 3, 4]),
-    };
+    const mockResponse: IcManagementDid.upload_canister_snapshot_metadata_response =
+      {
+        snapshot_id: Uint8Array.from([1, 2, 4, 3, 4]),
+      };
 
     const mockMetadata: UploadCanisterSnapshotMetadataParam = {
       globals: [{ i32: 5 }, { i64: 10n }],

--- a/packages/canisters/src/ic-management/ic-management.canister.ts
+++ b/packages/canisters/src/ic-management/ic-management.canister.ts
@@ -5,14 +5,7 @@ import {
   type QueryParams,
 } from "@dfinity/utils";
 import { Principal } from "@icp-sdk/core/principal";
-import type {
-  chunk_hash,
-  _SERVICE as IcManagementService,
-  list_canister_snapshots_result,
-  read_canister_snapshot_data_response,
-  take_canister_snapshot_result,
-  upload_canister_snapshot_metadata_response,
-} from "../declarations/ic-management/ic-management";
+import type { IcManagementDid, IcManagementService } from "../declarations";
 import { idlFactory as certifiedIdlFactory } from "../declarations/ic-management/ic-management.certified.idl";
 import { idlFactory } from "../declarations/ic-management/ic-management.idl";
 import type { ICManagementCanisterOptions } from "./types/canister.options";
@@ -161,7 +154,7 @@ export class ICManagementCanister {
   uploadChunk = ({
     canisterId,
     ...rest
-  }: UploadChunkParams): Promise<chunk_hash> => {
+  }: UploadChunkParams): Promise<IcManagementDid.chunk_hash> => {
     const { upload_chunk } = this.certifiedService;
 
     return upload_chunk({
@@ -199,7 +192,7 @@ export class ICManagementCanister {
    */
   storedChunks = ({
     canisterId,
-  }: StoredChunksParams): Promise<chunk_hash[]> => {
+  }: StoredChunksParams): Promise<IcManagementDid.chunk_hash[]> => {
     const { stored_chunks } = this.certifiedService;
 
     return stored_chunks({
@@ -380,7 +373,7 @@ export class ICManagementCanister {
    */
   takeCanisterSnapshot = (
     params: OptionSnapshotParams,
-  ): Promise<take_canister_snapshot_result> => {
+  ): Promise<IcManagementDid.take_canister_snapshot_result> => {
     const { take_canister_snapshot } = this.certifiedService;
 
     return take_canister_snapshot(toReplaceSnapshotArgs(params));
@@ -402,7 +395,7 @@ export class ICManagementCanister {
     canisterId,
   }: {
     canisterId: Principal;
-  }): Promise<list_canister_snapshots_result> => {
+  }): Promise<IcManagementDid.list_canister_snapshots_result> => {
     const { list_canister_snapshots } = this.certifiedService;
 
     return list_canister_snapshots({
@@ -499,7 +492,7 @@ export class ICManagementCanister {
   readCanisterSnapshotData = ({
     kind,
     ...params
-  }: ReadCanisterSnapshotDataParams): Promise<read_canister_snapshot_data_response> => {
+  }: ReadCanisterSnapshotDataParams): Promise<IcManagementDid.read_canister_snapshot_data_response> => {
     const { read_canister_snapshot_data } = this.certifiedService;
 
     return read_canister_snapshot_data({
@@ -525,7 +518,7 @@ export class ICManagementCanister {
   uploadCanisterSnapshotMetadata = ({
     metadata,
     ...params
-  }: UploadCanisterSnapshotMetadataParams): Promise<upload_canister_snapshot_metadata_response> => {
+  }: UploadCanisterSnapshotMetadataParams): Promise<IcManagementDid.upload_canister_snapshot_metadata_response> => {
     const { upload_canister_snapshot_metadata } = this.certifiedService;
 
     return upload_canister_snapshot_metadata({

--- a/packages/canisters/src/ic-management/index.ts
+++ b/packages/canisters/src/ic-management/index.ts
@@ -2,23 +2,7 @@
  * @module api/ic-management
  */
 
-export type {
-  canister_install_mode,
-  canister_log_record,
-  canister_status_result,
-  chunk_hash,
-  definite_canister_settings,
-  environment_variable,
-  fetch_canister_logs_result,
-  list_canister_snapshots_result,
-  log_visibility,
-  read_canister_snapshot_data_response,
-  read_canister_snapshot_metadata_response,
-  snapshot,
-  snapshot_id,
-  take_canister_snapshot_result,
-  upload_canister_snapshot_metadata_response,
-} from "../declarations/ic-management/ic-management";
+export type { IcManagementDid } from "../declarations";
 export { ICManagementCanister } from "./ic-management.canister";
 export * from "./types/canister.options";
 export * from "./types/ic-management.params";

--- a/packages/canisters/src/ic-management/types/canister.options.ts
+++ b/packages/canisters/src/ic-management/types/canister.options.ts
@@ -1,5 +1,5 @@
 import type { CanisterOptions } from "@dfinity/utils";
-import type { _SERVICE as IcManagementService } from "../../declarations/ic-management/ic-management";
+import type { IcManagementService } from "../../declarations";
 
 export type ICManagementCanisterOptions = Pick<
   CanisterOptions<IcManagementService>,

--- a/packages/canisters/src/ic-management/types/ic-management.params.ts
+++ b/packages/canisters/src/ic-management/types/ic-management.params.ts
@@ -1,13 +1,6 @@
 import { isNullish, type QueryParams, toNullable } from "@dfinity/utils";
 import { Principal } from "@icp-sdk/core/principal";
-import type {
-  canister_install_mode,
-  canister_settings,
-  chunk_hash,
-  environment_variable,
-  log_visibility,
-  upload_chunk_args,
-} from "../../declarations/ic-management/ic-management";
+import type { IcManagementDid } from "../../declarations";
 
 export enum LogVisibility {
   Controllers,
@@ -23,7 +16,7 @@ export interface CanisterSettings {
   logVisibility?: LogVisibility;
   wasmMemoryLimit?: bigint;
   wasmMemoryThreshold?: bigint;
-  environmentVariables?: environment_variable[];
+  environmentVariables?: IcManagementDid.environment_variable[];
 }
 
 export class UnsupportedLogVisibility extends Error {}
@@ -38,8 +31,8 @@ export const toCanisterSettings = ({
   wasmMemoryLimit,
   wasmMemoryThreshold,
   environmentVariables,
-}: CanisterSettings = {}): canister_settings => {
-  const toLogVisibility = (): log_visibility => {
+}: CanisterSettings = {}): IcManagementDid.canister_settings => {
+  const toLogVisibility = (): IcManagementDid.log_visibility => {
     switch (logVisibility) {
       case LogVisibility.Controllers:
         return { controllers: null };
@@ -75,14 +68,17 @@ export interface UpdateSettingsParams {
 }
 
 export interface InstallCodeParams {
-  mode: canister_install_mode;
+  mode: IcManagementDid.canister_install_mode;
   canisterId: Principal;
   wasmModule: Uint8Array;
   arg: Uint8Array;
   senderCanisterVersion?: bigint;
 }
 
-export interface UploadChunkParams extends Pick<upload_chunk_args, "chunk"> {
+export interface UploadChunkParams extends Pick<
+  IcManagementDid.upload_chunk_args,
+  "chunk"
+> {
   canisterId: Principal;
 }
 
@@ -98,7 +94,7 @@ export interface InstallChunkedCodeParams extends Omit<
   InstallCodeParams,
   "canisterId" | "wasmModule"
 > {
-  chunkHashesList: Array<chunk_hash>;
+  chunkHashesList: Array<IcManagementDid.chunk_hash>;
   targetCanisterId: Principal;
   storeCanisterId?: Principal;
   wasmModuleHash: string | Uint8Array;

--- a/packages/canisters/src/ic-management/types/ic-management.responses.ts
+++ b/packages/canisters/src/ic-management/types/ic-management.responses.ts
@@ -1,5 +1,5 @@
 import type { ServiceResponse } from "@dfinity/utils";
-import type { _SERVICE as IcManagementService } from "../../declarations/ic-management/ic-management";
+import type { IcManagementService } from "../../declarations";
 
 export type CanisterStatusResponse = ServiceResponse<
   IcManagementService,

--- a/packages/canisters/src/ic-management/types/snapshot.params.ts
+++ b/packages/canisters/src/ic-management/types/snapshot.params.ts
@@ -1,13 +1,6 @@
 import { assertNever, isNullish, nonNullish, toNullable } from "@dfinity/utils";
 import type { Principal } from "@icp-sdk/core/principal";
-import type {
-  canister_id,
-  read_canister_snapshot_data_args,
-  snapshot_id,
-  take_canister_snapshot_args,
-  upload_canister_snapshot_data_args,
-  upload_canister_snapshot_metadata_args,
-} from "../../declarations/ic-management/ic-management";
+import type { IcManagementDid } from "../../declarations";
 import { mapSnapshotId } from "../utils/ic-management.utils";
 import type { ReadCanisterSnapshotMetadataResponse } from "./snapshot.responses";
 
@@ -15,7 +8,7 @@ export type SnapshotIdText = string;
 
 export interface OptionSnapshotParams {
   canisterId: Principal;
-  snapshotId?: SnapshotIdText | snapshot_id;
+  snapshotId?: SnapshotIdText | IcManagementDid.snapshot_id;
 }
 
 export type SnapshotParams = Required<OptionSnapshotParams>;
@@ -23,7 +16,10 @@ export type SnapshotParams = Required<OptionSnapshotParams>;
 export const toSnapshotArgs = ({
   canisterId: canister_id,
   snapshotId,
-}: SnapshotParams): { canister_id: canister_id; snapshot_id: snapshot_id } => ({
+}: SnapshotParams): {
+  canister_id: IcManagementDid.canister_id;
+  snapshot_id: IcManagementDid.snapshot_id;
+} => ({
   canister_id,
   snapshot_id: mapSnapshotId(snapshotId),
 });
@@ -31,7 +27,7 @@ export const toSnapshotArgs = ({
 export const toReplaceSnapshotArgs = ({
   canisterId: canister_id,
   snapshotId,
-}: OptionSnapshotParams): take_canister_snapshot_args => ({
+}: OptionSnapshotParams): IcManagementDid.take_canister_snapshot_args => ({
   canister_id,
   replace_snapshot: toNullable(
     nonNullish(snapshotId) ? mapSnapshotId(snapshotId) : undefined,
@@ -50,7 +46,7 @@ export interface ReadCanisterSnapshotDataParams extends SnapshotParams {
 
 export const toCanisterSnapshotMetadataKind = (
   kind: CanisterSnapshotMetadataKind,
-): read_canister_snapshot_data_args["kind"] => {
+): IcManagementDid.read_canister_snapshot_data_args["kind"] => {
   if ("wasmModule" in kind) {
     return { wasm_module: kind.wasmModule };
   }
@@ -94,11 +90,11 @@ export const toUploadCanisterSnapshotMetadata = ({
   stableMemorySize: stable_memory_size,
   wasmMemorySize: wasm_memory_size,
 }: UploadCanisterSnapshotMetadataParam): Omit<
-  upload_canister_snapshot_metadata_args,
+  IcManagementDid.upload_canister_snapshot_metadata_args,
   "canister_id" | "replace_snapshot"
 > => {
   const mapOnLowWasmMemoryHookStatus =
-    (): upload_canister_snapshot_metadata_args["on_low_wasm_memory_hook_status"] => {
+    (): IcManagementDid.upload_canister_snapshot_metadata_args["on_low_wasm_memory_hook_status"] => {
       if (isNullish(onLowWasmMemoryHookStatus)) {
         return toNullable();
       }
@@ -141,7 +137,7 @@ export interface UploadCanisterSnapshotDataParams extends SnapshotParams {
 
 export const toUploadCanisterSnapshotDataKind = (
   kind: UploadCanisterSnapshotDataKind,
-): upload_canister_snapshot_data_args["kind"] => {
+): IcManagementDid.upload_canister_snapshot_data_args["kind"] => {
   if ("wasmModule" in kind) {
     return { wasm_module: kind.wasmModule };
   }

--- a/packages/canisters/src/ic-management/types/snapshot.responses.spec.ts
+++ b/packages/canisters/src/ic-management/types/snapshot.responses.spec.ts
@@ -1,29 +1,30 @@
-import type { read_canister_snapshot_metadata_response } from "../../declarations/ic-management/ic-management";
+import type { IcManagementDid } from "../../declarations";
 import {
   fromReadCanisterSnapshotMetadataResponse,
   type ReadCanisterSnapshotMetadataResponse,
 } from "./snapshot.responses";
 
 describe("snapshot.responses", () => {
-  const mockResponse: read_canister_snapshot_metadata_response = {
-    globals: [
-      { i32: 1 },
-      { i64: 2n },
-      { f32: 3.14 },
-      { f64: 6.28 },
-      { v128: 0n },
-    ],
-    canister_version: 42n,
-    source: { metadata_upload: { hello: "world test" } },
-    certified_data: new Uint8Array([1, 2, 3]),
-    global_timer: [],
-    on_low_wasm_memory_hook_status: [],
-    wasm_module_size: 1000n,
-    stable_memory_size: 2000n,
-    wasm_chunk_store: [{ hash: new Uint8Array([9, 9, 9]) }],
-    taken_at_timestamp: 123456789n,
-    wasm_memory_size: 3000n,
-  };
+  const mockResponse: IcManagementDid.read_canister_snapshot_metadata_response =
+    {
+      globals: [
+        { i32: 1 },
+        { i64: 2n },
+        { f32: 3.14 },
+        { f64: 6.28 },
+        { v128: 0n },
+      ],
+      canister_version: 42n,
+      source: { metadata_upload: { hello: "world test" } },
+      certified_data: new Uint8Array([1, 2, 3]),
+      global_timer: [],
+      on_low_wasm_memory_hook_status: [],
+      wasm_module_size: 1000n,
+      stable_memory_size: 2000n,
+      wasm_chunk_store: [{ hash: new Uint8Array([9, 9, 9]) }],
+      taken_at_timestamp: 123456789n,
+      wasm_memory_size: 3000n,
+    };
 
   it("should map fields", () => {
     const mapped = fromReadCanisterSnapshotMetadataResponse(mockResponse);
@@ -46,7 +47,7 @@ describe("snapshot.responses", () => {
   });
 
   it("should map source with taken_from_canister", () => {
-    const candid: read_canister_snapshot_metadata_response = {
+    const candid: IcManagementDid.read_canister_snapshot_metadata_response = {
       ...mockResponse,
       source: { taken_from_canister: { hello: "world" } },
     };
@@ -60,7 +61,7 @@ describe("snapshot.responses", () => {
 
   describe("global_timer", () => {
     it("should map active global_timer", () => {
-      const candid: read_canister_snapshot_metadata_response = {
+      const candid: IcManagementDid.read_canister_snapshot_metadata_response = {
         ...mockResponse,
         global_timer: [{ active: 787n }],
       };
@@ -71,7 +72,7 @@ describe("snapshot.responses", () => {
     });
 
     it("should map inactive global_timer", () => {
-      const candid: read_canister_snapshot_metadata_response = {
+      const candid: IcManagementDid.read_canister_snapshot_metadata_response = {
         ...mockResponse,
         global_timer: [{ inactive: null }],
       };
@@ -84,7 +85,7 @@ describe("snapshot.responses", () => {
 
   describe("onLowWasmMemoryHookStatus", () => {
     it("should map condition_not_satisfied", () => {
-      const candid: read_canister_snapshot_metadata_response = {
+      const candid: IcManagementDid.read_canister_snapshot_metadata_response = {
         ...mockResponse,
         on_low_wasm_memory_hook_status: [{ condition_not_satisfied: null }],
       };
@@ -97,7 +98,7 @@ describe("snapshot.responses", () => {
     });
 
     it("should map executed", () => {
-      const candid: read_canister_snapshot_metadata_response = {
+      const candid: IcManagementDid.read_canister_snapshot_metadata_response = {
         ...mockResponse,
         on_low_wasm_memory_hook_status: [{ executed: null }],
       };
@@ -110,7 +111,7 @@ describe("snapshot.responses", () => {
     });
 
     it("should map ready", () => {
-      const candid: read_canister_snapshot_metadata_response = {
+      const candid: IcManagementDid.read_canister_snapshot_metadata_response = {
         ...mockResponse,
         on_low_wasm_memory_hook_status: [{ ready: null }],
       };
@@ -121,7 +122,7 @@ describe("snapshot.responses", () => {
     });
 
     it("should stays undefined when empty", () => {
-      const candid: read_canister_snapshot_metadata_response = {
+      const candid: IcManagementDid.read_canister_snapshot_metadata_response = {
         ...mockResponse,
         on_low_wasm_memory_hook_status: [],
       };
@@ -136,7 +137,7 @@ describe("snapshot.responses", () => {
     const candid = {
       ...mockResponse,
       source: { something_else: 1 },
-    } as unknown as read_canister_snapshot_metadata_response;
+    } as unknown as IcManagementDid.read_canister_snapshot_metadata_response;
 
     expect(() => fromReadCanisterSnapshotMetadataResponse(candid)).toThrowError(
       "Unsupported snapshot metadata source",
@@ -147,7 +148,7 @@ describe("snapshot.responses", () => {
     const candid = {
       ...mockResponse,
       on_low_wasm_memory_hook_status: [{ unknown: null }],
-    } as unknown as read_canister_snapshot_metadata_response;
+    } as unknown as IcManagementDid.read_canister_snapshot_metadata_response;
 
     expect(() => fromReadCanisterSnapshotMetadataResponse(candid)).toThrowError(
       "Unsupported snapshot metadata on_low_wasm_memory_hook_status",

--- a/packages/canisters/src/ic-management/types/snapshot.responses.ts
+++ b/packages/canisters/src/ic-management/types/snapshot.responses.ts
@@ -1,5 +1,5 @@
 import { assertNever, fromNullable, isNullish } from "@dfinity/utils";
-import type { read_canister_snapshot_metadata_response } from "../../declarations/ic-management/ic-management";
+import type { IcManagementDid } from "../../declarations";
 
 export interface ReadCanisterSnapshotMetadataResponse {
   globals: (
@@ -36,7 +36,7 @@ export const fromReadCanisterSnapshotMetadataResponse = ({
   wasm_chunk_store: wasmChunkStore,
   taken_at_timestamp: takenAtTimestamp,
   wasm_memory_size: wasmMemorySize,
-}: read_canister_snapshot_metadata_response): ReadCanisterSnapshotMetadataResponse => {
+}: IcManagementDid.read_canister_snapshot_metadata_response): ReadCanisterSnapshotMetadataResponse => {
   const mapSource = (): ReadCanisterSnapshotMetadataResponse["source"] => {
     if ("metadata_upload" in source) {
       return { metadataUpload: source.metadata_upload };

--- a/packages/canisters/src/ic-management/utils/ic-management.utils.ts
+++ b/packages/canisters/src/ic-management/utils/ic-management.utils.ts
@@ -1,5 +1,5 @@
 import { hexStringToUint8Array, uint8ArrayToHexString } from "@dfinity/utils";
-import type { snapshot_id } from "../../declarations/ic-management/ic-management";
+import type { IcManagementDid } from "../../declarations";
 import type { SnapshotIdText } from "../types/snapshot.params";
 
 /**
@@ -12,8 +12,9 @@ import type { SnapshotIdText } from "../types/snapshot.params";
  * @param {snapshot_id} snapshotId - The snapshot ID to encode, represented as a `Uint8Array` or an array of numbers.
  * @returns {string} The hex string representation of the snapshot ID.
  */
-export const encodeSnapshotId = (snapshotId: snapshot_id): SnapshotIdText =>
-  uint8ArrayToHexString(snapshotId);
+export const encodeSnapshotId = (
+  snapshotId: IcManagementDid.snapshot_id,
+): SnapshotIdText => uint8ArrayToHexString(snapshotId);
 
 /**
  * Decodes a hex string representation of a snapshot ID back into its original format.
@@ -25,8 +26,9 @@ export const encodeSnapshotId = (snapshotId: snapshot_id): SnapshotIdText =>
  * @param {string} snapshotId - The hex string representation of the snapshot ID.
  * @returns {snapshot_id} The decoded snapshot ID as a `Uint8Array`.
  */
-export const decodeSnapshotId = (snapshotId: SnapshotIdText): snapshot_id =>
-  hexStringToUint8Array(snapshotId);
+export const decodeSnapshotId = (
+  snapshotId: SnapshotIdText,
+): IcManagementDid.snapshot_id => hexStringToUint8Array(snapshotId);
 
 /**
  * Maps a snapshot ID to the appropriate format for the IC interface.
@@ -38,6 +40,6 @@ export const decodeSnapshotId = (snapshotId: SnapshotIdText): snapshot_id =>
  * @returns {Uint8Array | number[]} The mapped snapshot ID.
  */
 export const mapSnapshotId = (
-  snapshotId: SnapshotIdText | snapshot_id,
-): snapshot_id =>
+  snapshotId: SnapshotIdText | IcManagementDid.snapshot_id,
+): IcManagementDid.snapshot_id =>
   typeof snapshotId === "string" ? decodeSnapshotId(snapshotId) : snapshotId;


### PR DESCRIPTION
# Motivation

We want to use the DID namespace pattern for the ic-mgmt.

# Changes

- Update imports
- Prefix types with namespace