### PR TITLE
chore(script): remove import cmc into legacy

### DIFF
--- a/scripts/import-candid
+++ b/scripts/import-candid
@@ -137,9 +137,6 @@ import_did "rs/sns/root/canister/root.did" "sns_root.did" "sns"
 import_did "rs/sns/governance/canister/governance.did" "sns_governance.did" "sns"
 patch_import_did "rs/sns/governance/canister/governance.did" "rs/sns/governance/canister/governance_test.did.patch" "sns_governance_test.did" "sns"
 
-mkdir -p packages/cmc/src/candid
-import_did "rs/nns/cmc/cmc.did" "cmc.did" "cmc"
-
 mkdir -p packages/ledger-icp/src/candid
 import_did "rs/ledger_suite/icp/ledger.did" "ledger.did" "ledger-icp"
 import_did "rs/ledger_suite/icp/index/index.did" "index.did" "ledger-icp"


### PR DESCRIPTION
# Motivation

In the weekly import candid  PR https://github.com/dfinity/icp-js-canisters/pull/1339 I noticed that the CMC DID file was incorrectly still imported in the legacy package (which we have now moved to the canisters lib).

# Changes

- Remove import line
