### PR TITLE
build(canisters): ckbtc dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2159,6 +2159,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base58-js": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-3.0.3.tgz",
+      "integrity": "sha512-3hf42BysHnUqmZO7mK6e5X/hs1AvyEJIhdVLbG/Mxn/fhFnhGxOO37mWbMHg1RT4TxqcPKXgqj9/bp1YG0GBXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
@@ -6738,6 +6748,11 @@
       "version": "2.0.1",
       "license": "Apache-2.0",
       "peer": true,
+      "dependencies": {
+        "@noble/hashes": "^1.8.0",
+        "base58-js": "^3.0.3",
+        "bech32": "^2.0.0"
+      },
       "peerDependencies": {
         "@dfinity/ckbtc": "^6",
         "@dfinity/cketh": "^6",
@@ -6753,6 +6768,7 @@
       "name": "@dfinity/ckbtc",
       "version": "6.0.1",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.8.0",
         "base58-js": "^3.0.3",
@@ -6761,16 +6777,6 @@
       "peerDependencies": {
         "@dfinity/utils": "^4",
         "@icp-sdk/core": "^4"
-      }
-    },
-    "packages/ckbtc/node_modules/base58-js": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-3.0.3.tgz",
-      "integrity": "sha512-3hf42BysHnUqmZO7mK6e5X/hs1AvyEJIhdVLbG/Mxn/fhFnhGxOO37mWbMHg1RT4TxqcPKXgqj9/bp1YG0GBXA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
       }
     },
     "packages/cketh": {
@@ -6906,13 +6912,6 @@
         "@noble/hashes": "^1.8.0",
         "base58-js": "^3.0.3",
         "bech32": "^2.0.0"
-      },
-      "dependencies": {
-        "base58-js": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-3.0.3.tgz",
-          "integrity": "sha512-3hf42BysHnUqmZO7mK6e5X/hs1AvyEJIhdVLbG/Mxn/fhFnhGxOO37mWbMHg1RT4TxqcPKXgqj9/bp1YG0GBXA=="
-        }
       }
     },
     "@dfinity/cketh": {
@@ -7351,7 +7350,11 @@
     },
     "@icp-sdk/canisters": {
       "version": "file:packages/canisters",
-      "requires": {}
+      "requires": {
+        "@noble/hashes": "^1.8.0",
+        "base58-js": "^3.0.3",
+        "bech32": "^2.0.0"
+      }
     },
     "@icp-sdk/core": {
       "version": "4.1.0",
@@ -8106,6 +8109,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "base58-js": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-3.0.3.tgz",
+      "integrity": "sha512-3hf42BysHnUqmZO7mK6e5X/hs1AvyEJIhdVLbG/Mxn/fhFnhGxOO37mWbMHg1RT4TxqcPKXgqj9/bp1YG0GBXA=="
     },
     "bech32": {
       "version": "2.0.0",

--- a/packages/canisters/package.json
+++ b/packages/canisters/package.json
@@ -96,5 +96,10 @@
     "@dfinity/sns": "^6",
     "@dfinity/utils": "^4",
     "@icp-sdk/core": "^4"
+  },
+  "dependencies": {
+    "@noble/hashes": "^1.8.0",
+    "base58-js": "^3.0.3",
+    "bech32": "^2.0.0"
   }
 }


### PR DESCRIPTION
# Motivation

CkBtc requires dependencies. As we are about to move the code to `@icp-sdk/canisters` in #1360 we have to add those dependencies to the multi-entries library as well.

# Changes

- Add same dependencies as in legacy `@dfinity/ckbtc` to canisters
