### PR TITLE
chore(canisters): options are types

### DIFF
--- a/packages/canisters/src/cmc/index.ts
+++ b/packages/canisters/src/cmc/index.ts
@@ -5,4 +5,4 @@
 export type { CmcDid } from "../declarations";
 export { CmcCanister } from "./cmc.canister";
 export * from "./cmc.errors";
-export * from "./cmc.options";
+export type * from "./cmc.options";

--- a/packages/canisters/src/ic-management/index.ts
+++ b/packages/canisters/src/ic-management/index.ts
@@ -4,7 +4,7 @@
 
 export type { IcManagementDid } from "../declarations";
 export { IcManagementCanister } from "./ic-management.canister";
-export * from "./types/canister.options";
+export type * from "./types/canister.options";
 export * from "./types/ic-management.params";
 export * from "./types/ic-management.responses";
 export * from "./types/snapshot.params";


### PR DESCRIPTION
# Motivation

I noticed that the re-exported options can be exposed as `export type ...`
