### PR TITLE
feat(canisters): remove now unused ckEth and ckBtc peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,10 @@
         "packages/ledger-icrc",
         "packages/nns",
         "packages/sns",
-        "packages/ckbtc",
-        "packages/cketh",
         "packages/zod-schemas",
         "packages/canisters",
+        "packages/ckbtc",
+        "packages/cketh",
         "packages/cmc",
         "packages/ic-management",
         "docs"
@@ -6754,8 +6754,6 @@
         "bech32": "^2.0.0"
       },
       "peerDependencies": {
-        "@dfinity/ckbtc": "^6",
-        "@dfinity/cketh": "^6",
         "@dfinity/ledger-icp": "^8",
         "@dfinity/ledger-icrc": "^6",
         "@dfinity/nns": "^11",
@@ -6768,7 +6766,6 @@
       "name": "@dfinity/ckbtc",
       "version": "6.0.1",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@icp-sdk/canisters": "^2"
       }
@@ -6777,7 +6774,6 @@
       "name": "@dfinity/cketh",
       "version": "6.0.1",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@icp-sdk/canisters": "^2"
       }

--- a/packages/canisters/package.json
+++ b/packages/canisters/package.json
@@ -88,8 +88,6 @@
   ],
   "homepage": "https://js.icp.build/canisters/",
   "peerDependencies": {
-    "@dfinity/ckbtc": "^6",
-    "@dfinity/cketh": "^6",
     "@dfinity/ledger-icp": "^8",
     "@dfinity/ledger-icrc": "^6",
     "@dfinity/nns": "^11",


### PR DESCRIPTION
# Motivation

We can remove `@dfinity/ckbtc` and cketh peer dependencies from `@icp-sdk/canisters`. The code has been integrated.
