### PR TITLE
feat(ledger-icp): list re-export types for index

### DIFF
--- a/packages/ledger-icp/src/index.ts
+++ b/packages/ledger-icp/src/index.ts
@@ -1,7 +1,4 @@
-// Reexport * because we cannot do otherwise for backwards compatibility as the all DID types of the index were exposed
-export type * from "@icp-sdk/canisters/ledger/icp";
-
-import type { IcpLedgerDid } from "@icp-sdk/canisters/ledger/icp";
+import type { IcpIndexDid, IcpLedgerDid } from "@icp-sdk/canisters/ledger/icp";
 
 export type Icrc1Account = IcpLedgerDid.Account;
 export type Icrc1ApproveError = IcpLedgerDid.ApproveError;
@@ -15,6 +12,14 @@ export type Icrc2ApproveResult = IcpLedgerDid.ApproveResult;
 export type Icrc2TransferFromError = IcpLedgerDid.TransferFromError;
 export type Icrc2TransferFromResult = IcpLedgerDid.TransferFromResult;
 export type Value = IcpLedgerDid.Value;
+
+export type GetAccountIdentifierTransactionsResponse =
+  IcpIndexDid.GetAccountIdentifierTransactionsResponse;
+export type TransactionWithId = IcpIndexDid.TransactionWithId;
+export type Transaction = IcpIndexDid.Transaction;
+export type Operation = IcpIndexDid.Operation;
+export type Tokens = IcpIndexDid.Tokens;
+export type TimeStamp = IcpIndexDid.TimeStamp;
 
 /**
  * @deprecated Use "@icp-sdk/canisters/ledger/icp" directly instead


### PR DESCRIPTION
# Motivation

We used to export everyting from `candid/index` but, we cannot do that with namespace.  Exporing `type *` won't resolve the issue therefore let's cherry pick few types corresponding to the functions exposed by the `IndexCanister` and hope it's enough for backwards compatibility.

Anyways, we recommend to start using the multi-entry library.

# Changes

- Cherry pick types
