### PR TITLE
docs(readme): review canister names

### DIFF
--- a/packages/ledger-icp/README.md
+++ b/packages/ledger-icp/README.md
@@ -32,20 +32,20 @@ npm i @icp-sdk/core @dfinity/utils
 
 ## Usage
 
-The features are available through the class `LedgerCanister`. It has to be instantiated with a canister ID.
+The features are available through the class `IcpLedgerCanister`. It has to be instantiated with a canister ID.
 
 e.g. fetching a token metadata.
 
 ```ts
 import { createAgent } from "@dfinity/utils";
-import { LedgerCanister } from "@dfinity/ledger-icp";
+import { IcpLedgerCanister } from "@dfinity/ledger-icp";
 
 const agent = await createAgent({
   identity,
   host: HOST,
 });
 
-const { metadata } = LedgerCanister.create({
+const { metadata } = IcpLedgerCanister.create({
   agent,
   canisterId: MY_LEDGER_CANISTER_ID,
 });

--- a/packages/nns/README.md
+++ b/packages/nns/README.md
@@ -32,7 +32,7 @@ npm i @icp-sdk/core @dfinity/utils
 Most features are provided through the use of classes. For example, querying the list of neurons controlled by the caller with the `governance` canister:
 
 ```ts
-import { GovernanceCanister } from "@dfinity/nns";
+import { NnsGovernanceCanister } from "@dfinity/nns";
 import { createAgent } from "@dfinity/utils";
 
 const agent = await createAgent({
@@ -40,7 +40,7 @@ const agent = await createAgent({
   host: HOST,
 });
 
-const { listNeurons } = GovernanceCanister.create({
+const { listNeurons } = NnsGovernanceCanister.create({
   agent,
   canisterId: MY_GOVERNANCE_CANISTER_ID,
 });
@@ -51,7 +51,7 @@ const myNeurons = await listNeurons({ certified: false });
 To execute this on a local environment, you will need to fetch the root key when initializing the agent. Additionally, you might need to adapt the port. The following snippet also demonstrates how you can inline a canister ID as well.
 
 ```typescript
-import { GovernanceCanister } from "@dfinity/nns";
+import { NnsGovernanceCanister } from "@dfinity/nns";
 import { Principal } from "@icp-sdk/core/principal";
 import { createAgent } from "@dfinity/utils";
 
@@ -61,7 +61,7 @@ const agent = await createAgent({
   fetchRootKey: true,
 });
 
-const { listNeurons } = GovernanceCanister.create({
+const { listNeurons } = NnsGovernanceCanister.create({
   agent,
   canisterId: Principal.fromText("rrkah-fqaaa-aaaaa-aaaaq-cai"),
 });

--- a/packages/sns/README.md
+++ b/packages/sns/README.md
@@ -44,7 +44,7 @@ const agent = await createAgent({
   host: HOST,
 });
 
-const snsWrapper = await initSnsWrapper({
+const wrapper = await initSnsWrapper({
   rootOptions: {
     canisterId: rootCanisterId,
   },


### PR DESCRIPTION
# Motivation

I just went quickly through the README's snippets to update the canister names with prefix.
While I was there I also spotted a typo in the Sns snippet.