### PR TITLE
fix(assets): use `require` for polyfills

### DIFF
--- a/packages/canisters/src/assets/utils/fs-polyfill.ts
+++ b/packages/canisters/src/assets/utils/fs-polyfill.ts
@@ -10,10 +10,8 @@ const browserFs: typeof fs = {};
 
 // Export either the real fs module or the polyfill
 const fsPolyfill: typeof fs = isNode
-  ? // In Node.js, use the real fs module with dynamic import
-    // This allows bundlers to properly handle the conditional import
-    await import("fs").then((mod) => mod.default)
-  : // In browser, use the polyfill
-    browserFs;
+  ? // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("fs")
+  : browserFs;
 
 export default fsPolyfill;

--- a/packages/canisters/src/assets/utils/path-polyfill.ts
+++ b/packages/canisters/src/assets/utils/path-polyfill.ts
@@ -8,12 +8,9 @@ const isNode = typeof window === "undefined";
 // @ts-expect-error - path is not defined in the browser
 const browserPath: typeof path = {};
 
-// Export either the real path module or the polyfill
 const pathPolyfill: typeof path = isNode
-  ? // In Node.js, use the real path module with dynamic import
-    // This allows bundlers to properly handle the conditional import
-    await import("path").then((mod) => mod.default)
-  : // In browser, use the polyfill
-    browserPath;
+  ? // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("path")
+  : browserPath;
 
 export default pathPolyfill;


### PR DESCRIPTION
# Motivation

Import `fs` and `path` using `require` instead of the asynchronous dynamic `import`.

# Changes

- Replaced `await import` with `require` in the assets' polyfills
