### PR TITLE
ci(integration-tests): bump dfx to v0.30.1-beta.2

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -149,7 +149,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: dfinity/setup-dfx@main
         with: 
-          dfx-version: "0.30.1-beta.1"
+          dfx-version: "0.30.1-beta.2"
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Build


### PR DESCRIPTION
Bumps dfx to the latest beta version before stable release to test if everything still works as expected.

After stable dfx 0.30.1 is released, I'll update it here.