### PR TITLE
build(core): bump bindgen minor security patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       ],
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.2.3",
-        "@icp-sdk/bindgen": "^0.2.0",
+        "@icp-sdk/bindgen": "^0.2.1",
         "@size-limit/esbuild": "^12.0.0",
         "@size-limit/preset-small-lib": "^12.0.0",
         "@types/node": "^24.10.1",
@@ -902,13 +902,13 @@
       }
     },
     "node_modules/@icp-sdk/bindgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@icp-sdk/bindgen/-/bindgen-0.2.0.tgz",
-      "integrity": "sha512-LUCgnZSvCtcCnJro9pS8/YQ3k/EPDiY6wx/8dxgGMM+A1PsdPUIzdQJYV4aQibjGZyc+v74EtpXfiM2UsfOWlw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@icp-sdk/bindgen/-/bindgen-0.2.1.tgz",
+      "integrity": "sha512-/YXJcYdqb4Qi+c33NVU8BgY4O/ZVqOQy+eYH4fSu5asT5/eAQl5NNgsjMTkhbGknRbxm8N9/ZopzAf2GX0n5lg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "commander": "^14.0.1"
+        "commander": "^14.0.2"
       },
       "bin": {
         "icp-bindgen": "dist/esm/cli/icp-bindgen.js"
@@ -7331,12 +7331,12 @@
       "dev": true
     },
     "@icp-sdk/bindgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@icp-sdk/bindgen/-/bindgen-0.2.0.tgz",
-      "integrity": "sha512-LUCgnZSvCtcCnJro9pS8/YQ3k/EPDiY6wx/8dxgGMM+A1PsdPUIzdQJYV4aQibjGZyc+v74EtpXfiM2UsfOWlw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@icp-sdk/bindgen/-/bindgen-0.2.1.tgz",
+      "integrity": "sha512-/YXJcYdqb4Qi+c33NVU8BgY4O/ZVqOQy+eYH4fSu5asT5/eAQl5NNgsjMTkhbGknRbxm8N9/ZopzAf2GX0n5lg==",
       "dev": true,
       "requires": {
-        "commander": "^14.0.1"
+        "commander": "^14.0.2"
       }
     },
     "@icp-sdk/canisters": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@dfinity/eslint-config-oisy-wallet": "^0.2.3",
-    "@icp-sdk/bindgen": "^0.2.0",
+    "@icp-sdk/bindgen": "^0.2.1",
     "@size-limit/esbuild": "^12.0.0",
     "@size-limit/preset-small-lib": "^12.0.0",
     "@types/node": "^24.10.1",


### PR DESCRIPTION
# Motivation

Bindgen - the tool to generate the IDL files - was patched to escape `*/ ` to prevent premature doc comment termination (see [CHANGELOG](https://github.com/dfinity/icp-js-bindgen/blob/main/CHANGELOG.md#fix)) or in other words, was patched to prevent JS code block provided as documentation to potentially be run when modules are evaluated at runtime.

# Changes

- ` npm rm @icp-sdk/bindgen && npm i @icp-sdk/bindgen -D`
