### PR TITLE
ci(integration-tests): set dfx version to latest

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -148,8 +148,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: dfinity/setup-dfx@main
-        with: 
-          dfx-version: "0.30.1-beta.2"
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Build


### PR DESCRIPTION
# Motivation

Since [v0.30.1](https://github.com/dfinity/sdk/releases/tag/0.30.1) is out, we can default the CI version of dfx to latest.

# Changes

- Removed the explicit version from the setup dfx step
