### PR TITLE
chore(ci): use Node LTS for size checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -163,6 +163,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Prepare
+        uses: ./.github/actions/prepare
       - name: Size check
         # The limits are defined in package.json.
         uses: andresz1/size-limit-action@v1


### PR DESCRIPTION
# Motivation

Turns out - as I discovered in Juno and here in  #1432 - we do not set the Node version for the size comparison. As a result, the checks runs with a deprecated version of Node.

# Changes

- Use prepare scripts for size checks as well