### PR TITLE
chore(ledger): remove placeholder for 2 years old deprecated lib

### DIFF
--- a/packages/ledger/README.md
+++ b/packages/ledger/README.md
@@ -1,3 +1,0 @@
-# ledger-js
-
-⚠️ The library `@dfinity/ledger` has been deprecated, renamed, and replaced by [@dfinity/ledger-icrc](../ledger-icrc).


### PR DESCRIPTION
# Motivation

We deprecated `@dfinity/ledger` more than two years ago, I guess we can safely remove the placeholder we had in the repo now.

# Notes

I asked IT to deprecate the lib on npm https://www.npmjs.com/package/@dfinity/ledger. Looks like we never did it yet.