### PR TITLE
feat(devops): Disable format auto-commit for external PRs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,9 +18,10 @@ jobs:
       - name: Check if commits can be added
         id: check_can_add_commit
         run: |
-          echo "can_add_commit=${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY != '' && github.event_name == 'pull_request' }}" >> $GITHUB_OUTPUT
+          echo "can_add_commit=${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY != '' && vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID != '' && github.event_name == 'pull_request' }}" >> $GITHUB_OUTPUT
 
       - name: Create GitHub App Token
+        if: steps.check_can_add_commit.outputs.can_add_commit == 'true'
         uses: actions/create-github-app-token@v1
         id: app-token
         with:
@@ -34,12 +35,14 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.app-token.outputs.token }}
+
       - name: Checkout
         if: steps.check_can_add_commit.outputs.can_add_commit == 'false'
         uses: actions/checkout@v4
 
       - name: Install shfmt
         run: sudo snap install --classic shfmt
+
       - name: Format shell scripts
         run: ./scripts/fmt-sh
 
@@ -57,6 +60,7 @@ jobs:
           else
             echo "formatting_needed=true" >> $GITHUB_OUTPUT
           fi
+
       - name: Commit Formatting changes
         if: steps.check_can_add_commit.outputs.can_add_commit == 'true' && steps.check_format.outputs.formatting_needed == 'true'
         uses: EndBug/add-and-commit@v9.1.4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,9 +17,10 @@ jobs:
       - name: Check if commits can be added
         id: check_can_add_commit
         run: |
-          echo "can_add_commit=${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY != '' && github.event_name == 'pull_request' }}" >> $GITHUB_OUTPUT
+          echo "can_add_commit=${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY != '' && vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID != '' && github.event_name == 'pull_request' }}" >> $GITHUB_OUTPUT
 
       - name: Create GitHub App Token
+        if: steps.check_can_add_commit.outputs.can_add_commit == 'true'
         uses: actions/create-github-app-token@v1
         id: app-token
         with:
@@ -33,6 +34,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.app-token.outputs.token }}
+
       - name: Checkout without token
         if: steps.check_can_add_commit.outputs.can_add_commit == 'false'
         uses: actions/checkout@v4
@@ -63,6 +65,7 @@ jobs:
           else
             echo "docs_needed=true" >> $GITHUB_OUTPUT
           fi
+
       - name: Commit docs changes
         if: steps.check_can_add_commit.outputs.can_add_commit == 'true' && steps.check_docs.outputs.docs_needed == 'true'
         uses: EndBug/add-and-commit@v9.1.4


### PR DESCRIPTION
# Motivation

As suggested by @peterpeterparker in https://github.com/dfinity/icp-js-canisters/pull/1457#issuecomment-3890719915, we should disable the auto-commit CI for external PRs, since they have no access to our GITHUB vars.

To really test the solution, I am submitting the PR from a forked repo (hopefully it is not a false positive, even if I am part of the CODEOWNERS...).