### PR TITLE
feat(canisters): ic-mgmt snapshot visibility

### DIFF
--- a/packages/canisters/src/declarations/ic-management/ic-management.certified.idl.js
+++ b/packages/canisters/src/declarations/ic-management/ic-management.certified.idl.js
@@ -145,6 +145,11 @@ export const idlFactory = ({ IDL }) => {
     public: IDL.Null,
     allowed_viewers: IDL.Vec(IDL.Principal),
   });
+  const snapshot_visibility = IDL.Variant({
+    controllers: IDL.Null,
+    public: IDL.Null,
+    allowed_viewers: IDL.Vec(IDL.Principal),
+  });
   const definite_canister_settings = IDL.Record({
     freezing_threshold: IDL.Nat,
     wasm_memory_threshold: IDL.Nat,
@@ -152,6 +157,7 @@ export const idlFactory = ({ IDL }) => {
     controllers: IDL.Vec(IDL.Principal),
     reserved_cycles_limit: IDL.Nat,
     log_visibility: log_visibility,
+    snapshot_visibility: snapshot_visibility,
     wasm_memory_limit: IDL.Nat,
     memory_allocation: IDL.Nat,
     compute_allocation: IDL.Nat,
@@ -195,6 +201,7 @@ export const idlFactory = ({ IDL }) => {
     controllers: IDL.Opt(IDL.Vec(IDL.Principal)),
     reserved_cycles_limit: IDL.Opt(IDL.Nat),
     log_visibility: IDL.Opt(log_visibility),
+    snapshot_visibility: IDL.Opt(snapshot_visibility),
     wasm_memory_limit: IDL.Opt(IDL.Nat),
     memory_allocation: IDL.Opt(IDL.Nat),
     compute_allocation: IDL.Opt(IDL.Nat),

--- a/packages/canisters/src/declarations/ic-management/ic-management.d.ts
+++ b/packages/canisters/src/declarations/ic-management/ic-management.d.ts
@@ -94,6 +94,7 @@ export interface canister_settings {
   controllers: [] | [Array<Principal>];
   reserved_cycles_limit: [] | [bigint];
   log_visibility: [] | [log_visibility];
+  snapshot_visibility: [] | [snapshot_visibility];
   wasm_memory_limit: [] | [bigint];
   memory_allocation: [] | [bigint];
   compute_allocation: [] | [bigint];
@@ -198,6 +199,7 @@ export interface definite_canister_settings {
   controllers: Array<Principal>;
   reserved_cycles_limit: bigint;
   log_visibility: log_visibility;
+  snapshot_visibility: snapshot_visibility;
   wasm_memory_limit: bigint;
   memory_allocation: bigint;
   compute_allocation: bigint;
@@ -392,6 +394,10 @@ export interface snapshot {
   taken_at_timestamp: bigint;
 }
 export type snapshot_id = Uint8Array;
+export type snapshot_visibility =
+  | { controllers: null }
+  | { public: null }
+  | { allowed_viewers: Array<Principal> };
 export interface start_canister_args {
   canister_id: canister_id;
 }

--- a/packages/canisters/src/declarations/ic-management/ic-management.did
+++ b/packages/canisters/src/declarations/ic-management/ic-management.did
@@ -1,10 +1,16 @@
-// Generated from dfinity/portal commit 2cc3d2a572c70234c046c66da1b0a294e5a64a15 for file 'docs/references/_attachments/ic.did'
+// Generated from dfinity/portal commit b8e9eff00e648fed39582848b650d952fe0674d1 for file 'docs/references/_attachments/ic.did'
 
 type canister_id = principal;
 type wasm_module = blob;
 type snapshot_id = blob;
 
 type log_visibility = variant {
+    controllers;
+    public;
+    allowed_viewers : vec principal;
+};
+
+type snapshot_visibility = variant {
     controllers;
     public;
     allowed_viewers : vec principal;
@@ -22,6 +28,7 @@ type canister_settings = record {
     freezing_threshold : opt nat;
     reserved_cycles_limit : opt nat;
     log_visibility : opt log_visibility;
+    snapshot_visibility : opt snapshot_visibility;
     wasm_memory_limit : opt nat;
     wasm_memory_threshold : opt nat;
     environment_variables : opt vec environment_variable;
@@ -34,6 +41,7 @@ type definite_canister_settings = record {
     freezing_threshold : nat;
     reserved_cycles_limit : nat;
     log_visibility : log_visibility;
+    snapshot_visibility : snapshot_visibility;
     wasm_memory_limit : nat;
     wasm_memory_threshold : nat;
     environment_variables : vec environment_variable;

--- a/packages/canisters/src/declarations/ic-management/ic-management.idl.js
+++ b/packages/canisters/src/declarations/ic-management/ic-management.idl.js
@@ -145,6 +145,11 @@ export const idlFactory = ({ IDL }) => {
     public: IDL.Null,
     allowed_viewers: IDL.Vec(IDL.Principal),
   });
+  const snapshot_visibility = IDL.Variant({
+    controllers: IDL.Null,
+    public: IDL.Null,
+    allowed_viewers: IDL.Vec(IDL.Principal),
+  });
   const definite_canister_settings = IDL.Record({
     freezing_threshold: IDL.Nat,
     wasm_memory_threshold: IDL.Nat,
@@ -152,6 +157,7 @@ export const idlFactory = ({ IDL }) => {
     controllers: IDL.Vec(IDL.Principal),
     reserved_cycles_limit: IDL.Nat,
     log_visibility: log_visibility,
+    snapshot_visibility: snapshot_visibility,
     wasm_memory_limit: IDL.Nat,
     memory_allocation: IDL.Nat,
     compute_allocation: IDL.Nat,
@@ -195,6 +201,7 @@ export const idlFactory = ({ IDL }) => {
     controllers: IDL.Opt(IDL.Vec(IDL.Principal)),
     reserved_cycles_limit: IDL.Opt(IDL.Nat),
     log_visibility: IDL.Opt(log_visibility),
+    snapshot_visibility: IDL.Opt(snapshot_visibility),
     wasm_memory_limit: IDL.Opt(IDL.Nat),
     memory_allocation: IDL.Opt(IDL.Nat),
     compute_allocation: IDL.Opt(IDL.Nat),

--- a/packages/canisters/src/ic-management/ic-management.canister.spec.ts
+++ b/packages/canisters/src/ic-management/ic-management.canister.spec.ts
@@ -16,7 +16,6 @@ import {
   mockPrincipalText,
 } from "./ic-management.mock";
 import {
-  type SnapshotVisibility,
   LogVisibility,
   SnapshotVisibilityType,
   UnsupportedLogVisibility,
@@ -25,6 +24,7 @@ import {
   type ClearChunkStoreParams,
   type InstallChunkedCodeParams,
   type InstallCodeParams,
+  type SnapshotVisibility,
   type StoredChunksParams,
   type UploadChunkParams,
 } from "./types/ic-management.params";

--- a/packages/canisters/src/ic-management/ic-management.canister.spec.ts
+++ b/packages/canisters/src/ic-management/ic-management.canister.spec.ts
@@ -16,8 +16,11 @@ import {
   mockPrincipalText,
 } from "./ic-management.mock";
 import {
+  type SnapshotVisibility,
   LogVisibility,
+  SnapshotVisibilityType,
   UnsupportedLogVisibility,
+  UnsupportedSnapshotVisibility,
   type CanisterSettings,
   type ClearChunkStoreParams,
   type InstallChunkedCodeParams,
@@ -189,6 +192,7 @@ describe("IcManagementCanister", () => {
           memory_allocation: [],
           reserved_cycles_limit: [],
           log_visibility: [],
+          snapshot_visibility: [],
           wasm_memory_limit: [],
           wasm_memory_threshold: [],
           environment_variables: [],
@@ -196,70 +200,169 @@ describe("IcManagementCanister", () => {
       });
     });
 
-    it("calls update_settings with mapped log_visibility controllers", async () => {
-      const service = mock<IcManagementService>();
-      service.update_settings.mockResolvedValue(undefined);
+    describe("log_visibility", () => {
+      it("calls update_settings with mapped log_visibility controllers", async () => {
+        const service = mock<IcManagementService>();
+        service.update_settings.mockResolvedValue(undefined);
 
-      const icManagement = await createIcManagement(service);
+        const icManagement = await createIcManagement(service);
 
-      await icManagement.updateSettings({
-        canisterId: mockCanisterId,
-        settings: {
-          ...mockCanisterSettings,
-          logVisibility: LogVisibility.Controllers,
-        },
-      });
-
-      expect(service.update_settings).toHaveBeenCalledWith({
-        canister_id: mockCanisterId,
-        settings: {
-          ...mappedMockCanisterSettings,
-          log_visibility: [{ controllers: null }],
-        },
-        sender_canister_version: [],
-      });
-    });
-
-    it("calls update_settings with mapped log_visibility public", async () => {
-      const service = mock<IcManagementService>();
-      service.update_settings.mockResolvedValue(undefined);
-
-      const icManagement = await createIcManagement(service);
-
-      await icManagement.updateSettings({
-        canisterId: mockCanisterId,
-        settings: {
-          ...mockCanisterSettings,
-          logVisibility: LogVisibility.Public,
-        },
-      });
-
-      expect(service.update_settings).toHaveBeenCalledWith({
-        canister_id: mockCanisterId,
-        settings: {
-          ...mappedMockCanisterSettings,
-          log_visibility: [{ public: null }],
-        },
-        sender_canister_version: [],
-      });
-    });
-
-    it("throws Error for unsupported log visibility", async () => {
-      const service = mock<IcManagementService>();
-      service.update_settings.mockResolvedValue(undefined);
-
-      const icManagement = await createIcManagement(service);
-
-      const call = () =>
-        icManagement.updateSettings({
+        await icManagement.updateSettings({
           canisterId: mockCanisterId,
           settings: {
             ...mockCanisterSettings,
-            logVisibility: 2 as unknown as LogVisibility,
+            logVisibility: LogVisibility.Controllers,
           },
         });
 
-      expect(call).toThrowError(UnsupportedLogVisibility);
+        expect(service.update_settings).toHaveBeenCalledWith({
+          canister_id: mockCanisterId,
+          settings: {
+            ...mappedMockCanisterSettings,
+            log_visibility: [{ controllers: null }],
+          },
+          sender_canister_version: [],
+        });
+      });
+
+      it("calls update_settings with mapped log_visibility public", async () => {
+        const service = mock<IcManagementService>();
+        service.update_settings.mockResolvedValue(undefined);
+
+        const icManagement = await createIcManagement(service);
+
+        await icManagement.updateSettings({
+          canisterId: mockCanisterId,
+          settings: {
+            ...mockCanisterSettings,
+            logVisibility: LogVisibility.Public,
+          },
+        });
+
+        expect(service.update_settings).toHaveBeenCalledWith({
+          canister_id: mockCanisterId,
+          settings: {
+            ...mappedMockCanisterSettings,
+            log_visibility: [{ public: null }],
+          },
+          sender_canister_version: [],
+        });
+      });
+
+      it("throws Error for unsupported log visibility", async () => {
+        const service = mock<IcManagementService>();
+        service.update_settings.mockResolvedValue(undefined);
+
+        const icManagement = await createIcManagement(service);
+
+        const call = () =>
+          icManagement.updateSettings({
+            canisterId: mockCanisterId,
+            settings: {
+              ...mockCanisterSettings,
+              logVisibility: 2 as unknown as LogVisibility,
+            },
+          });
+
+        expect(call).toThrowError(UnsupportedLogVisibility);
+      });
+    });
+
+    describe("snapshot_visibility", () => {
+      it("calls update_settings with mapped snapshot_visibility controllers", async () => {
+        const service = mock<IcManagementService>();
+        service.update_settings.mockResolvedValue(undefined);
+
+        const icManagement = await createIcManagement(service);
+
+        await icManagement.updateSettings({
+          canisterId: mockCanisterId,
+          settings: {
+            ...mockCanisterSettings,
+            snapshotVisibility: { type: SnapshotVisibilityType.Controllers },
+          },
+        });
+
+        expect(service.update_settings).toHaveBeenCalledWith({
+          canister_id: mockCanisterId,
+          settings: {
+            ...mappedMockCanisterSettings,
+            snapshot_visibility: [{ controllers: null }],
+          },
+          sender_canister_version: [],
+        });
+      });
+
+      it("calls update_settings with mapped snapshot_visibility public", async () => {
+        const service = mock<IcManagementService>();
+        service.update_settings.mockResolvedValue(undefined);
+
+        const icManagement = await createIcManagement(service);
+
+        await icManagement.updateSettings({
+          canisterId: mockCanisterId,
+          settings: {
+            ...mockCanisterSettings,
+            snapshotVisibility: { type: SnapshotVisibilityType.Public },
+          },
+        });
+
+        expect(service.update_settings).toHaveBeenCalledWith({
+          canister_id: mockCanisterId,
+          settings: {
+            ...mappedMockCanisterSettings,
+            snapshot_visibility: [{ public: null }],
+          },
+          sender_canister_version: [],
+        });
+      });
+
+      it("calls update_settings with mapped snapshot_visibility allowed_viewers", async () => {
+        const service = mock<IcManagementService>();
+        service.update_settings.mockResolvedValue(undefined);
+
+        const icManagement = await createIcManagement(service);
+
+        await icManagement.updateSettings({
+          canisterId: mockCanisterId,
+          settings: {
+            ...mockCanisterSettings,
+            snapshotVisibility: {
+              type: SnapshotVisibilityType.AllowedViewers,
+              viewers: [mockPrincipalText],
+            },
+          },
+        });
+
+        expect(service.update_settings).toHaveBeenCalledWith({
+          canister_id: mockCanisterId,
+          settings: {
+            ...mappedMockCanisterSettings,
+            snapshot_visibility: [{ allowed_viewers: [mockPrincipal] }],
+          },
+          sender_canister_version: [],
+        });
+      });
+
+      it("throws Error for unsupported snapshot visibility", async () => {
+        const service = mock<IcManagementService>();
+        service.update_settings.mockResolvedValue(undefined);
+
+        const icManagement = await createIcManagement(service);
+
+        const call = () =>
+          icManagement.updateSettings({
+            canisterId: mockCanisterId,
+            settings: {
+              ...mockCanisterSettings,
+              snapshotVisibility: {
+                type: 99 as unknown as SnapshotVisibilityType,
+              } as unknown as SnapshotVisibility,
+            },
+          });
+
+        expect(call).toThrowError(UnsupportedSnapshotVisibility);
+      });
     });
 
     it("throws Error", async () => {
@@ -416,6 +519,7 @@ describe("IcManagementCanister", () => {
       compute_allocation: BigInt(10),
       reserved_cycles_limit: BigInt(11),
       log_visibility: { controllers: null },
+      snapshot_visibility: { public: null },
       wasm_memory_limit: BigInt(500_00),
       wasm_memory_threshold: BigInt(100),
       environment_variables: [],

--- a/packages/canisters/src/ic-management/types/ic-management.params.ts
+++ b/packages/canisters/src/ic-management/types/ic-management.params.ts
@@ -7,6 +7,17 @@ export enum LogVisibility {
   Public,
 }
 
+export enum SnapshotVisibilityType {
+  Controllers,
+  Public,
+  AllowedViewers,
+}
+
+export type SnapshotVisibility =
+  | { type: SnapshotVisibilityType.Controllers }
+  | { type: SnapshotVisibilityType.Public }
+  | { type: SnapshotVisibilityType.AllowedViewers; viewers: string[] };
+
 export interface CanisterSettings {
   controllers?: string[];
   freezingThreshold?: bigint;
@@ -14,12 +25,14 @@ export interface CanisterSettings {
   computeAllocation?: bigint;
   reservedCyclesLimit?: bigint;
   logVisibility?: LogVisibility;
+  snapshotVisibility?: SnapshotVisibility;
   wasmMemoryLimit?: bigint;
   wasmMemoryThreshold?: bigint;
   environmentVariables?: IcManagementDid.environment_variable[];
 }
 
 export class UnsupportedLogVisibility extends Error {}
+export class UnsupportedSnapshotVisibility extends Error {}
 
 export const toCanisterSettings = ({
   controllers,
@@ -28,6 +41,7 @@ export const toCanisterSettings = ({
   computeAllocation,
   reservedCyclesLimit,
   logVisibility,
+  snapshotVisibility,
   wasmMemoryLimit,
   wasmMemoryThreshold,
   environmentVariables,
@@ -43,6 +57,25 @@ export const toCanisterSettings = ({
     }
   };
 
+  const toSnapshotVisibility = (
+    snapshotVisibility: SnapshotVisibility,
+  ): IcManagementDid.snapshot_visibility => {
+    switch (snapshotVisibility.type) {
+      case SnapshotVisibilityType.AllowedViewers:
+        return {
+          allowed_viewers: snapshotVisibility.viewers.map((principalText) =>
+            Principal.fromText(principalText),
+          ),
+        };
+      case SnapshotVisibilityType.Public:
+        return { public: null };
+      case SnapshotVisibilityType.Controllers:
+        return { controllers: null };
+      default:
+        throw new UnsupportedSnapshotVisibility();
+    }
+  };
+
   return {
     controllers: toNullable(controllers?.map((c) => Principal.fromText(c))),
     freezing_threshold: toNullable(freezingThreshold),
@@ -50,6 +83,9 @@ export const toCanisterSettings = ({
     compute_allocation: toNullable(computeAllocation),
     reserved_cycles_limit: toNullable(reservedCyclesLimit),
     log_visibility: isNullish(logVisibility) ? [] : [toLogVisibility()],
+    snapshot_visibility: isNullish(snapshotVisibility)
+      ? []
+      : [toSnapshotVisibility(snapshotVisibility)],
     wasm_memory_limit: toNullable(wasmMemoryLimit),
     wasm_memory_threshold: toNullable(wasmMemoryThreshold),
     environment_variables: toNullable(environmentVariables),


### PR DESCRIPTION
# Motivation

`snapshot_visibility` has been added to the IC-management.

# Changes

- Cherry pick did changes from #1504
- Add support with a related type and mapper

