### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Create GitHub App Token
         if: steps.check_can_add_commit.outputs.can_add_commit == 'true'
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
@@ -63,7 +63,7 @@ jobs:
 
       - name: Commit Formatting changes
         if: steps.check_can_add_commit.outputs.can_add_commit == 'true' && steps.check_format.outputs.formatting_needed == 'true'
-        uses: EndBug/add-and-commit@v9.1.4
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         with:
           add: .
           default_author: github_actions
@@ -158,7 +158,7 @@ jobs:
         uses: ./.github/actions/prepare
       - name: Size check
         # The limits are defined in package.json.
-        uses: andresz1/size-limit-action@v1
+        uses: andresz1/size-limit-action@e7493a72a44b113341c0cf6186ab49c17c4b65c1 # v1.6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Create GitHub App Token
         if: steps.check_can_add_commit.outputs.can_add_commit == 'true'
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
@@ -49,7 +49,7 @@ jobs:
         run: npm run docs
 
       - name: Commit docs
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         # We don't want to commit documentation changes to main
         if: ${{ github.ref != 'refs/heads/main' }}
         with:
@@ -68,7 +68,7 @@ jobs:
 
       - name: Commit docs changes
         if: steps.check_can_add_commit.outputs.can_add_commit == 'true' && steps.check_docs.outputs.docs_needed == 'true'
-        uses: EndBug/add-and-commit@v9.1.4
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         with:
           add: .
           default_author: github_actions

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
 
-      - uses: dfinity/ci-tools/actions/extract-version@main
+      - uses: dfinity/ci-tools/actions/extract-version@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
         id: extract-version
         with:
             file: packages/canisters/package.json
@@ -67,7 +67,7 @@ jobs:
           path: icp-pages
 
       - name: Assemble docs
-        uses: dfinity/ci-tools/actions/assemble-docs@main
+        uses: dfinity/ci-tools/actions/assemble-docs@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
         with:
           assets_dir: 'docs/dist/${{ steps.ver.outputs.major_version }}'
           version: ${{ steps.ver.outputs.major_version }}
@@ -76,7 +76,7 @@ jobs:
           version_in_title: ${{ steps.ver.outputs.major_minor_patch_version }}
 
       - name: Assemble docs
-        uses: dfinity/ci-tools/actions/assemble-docs@main
+        uses: dfinity/ci-tools/actions/assemble-docs@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
         with:
           assets_dir: 'docs/dist/latest'
           version: 'latest'
@@ -84,7 +84,7 @@ jobs:
           version_label: 'Latest (${{ steps.ver.outputs.major_minor_patch_version }})'
 
       - name: Submit Documentation
-        uses: dfinity/ci-tools/actions/submit-docs@main
+        uses: dfinity/ci-tools/actions/submit-docs@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
         with:
           destination_repo: 'dfinity/icp-js-sdk-docs'
           token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dfinity/setup-dfx@main
+      - uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Build

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
@@ -67,7 +67,7 @@ jobs:
           fi
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ steps.app-token.outputs.token }}
           base: main


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/create-github-app-token@v1` -> `actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0`
  - Version: v1.12.0 | Latest: v3.0.0 | Release age: 26d
  - Commit: https://github.com/actions/create-github-app-token/commit/d72941d797fd3113feb6b93fd0dec494b13a2547

- `EndBug/add-and-commit@v9.1.4` -> `EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4`
  - Version: v9.1.4 | Latest: v10.0.0 | Release age: 17d
  - Commit: https://github.com/EndBug/add-and-commit/commit/a94899bca583c204427a224a7af87c02f9b325d5

- `andresz1/size-limit-action@v1` -> `andresz1/size-limit-action@e7493a72a44b113341c0cf6186ab49c17c4b65c1 # v1.6.1`
  - Version: v1.6.1 | Latest: v1.8.0 | Release age: 732d
  - Commit: https://github.com/andresz1/size-limit-action/commit/e7493a72a44b113341c0cf6186ab49c17c4b65c1

- `EndBug/add-and-commit@v9` -> `EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4`
  - Version: v9.1.4 | Latest: v10.0.0 | Release age: 17d
  - Commit: https://github.com/EndBug/add-and-commit/commit/a94899bca583c204427a224a7af87c02f9b325d5

- `dfinity/ci-tools/actions/extract-version@main` -> `dfinity/ci-tools/actions/extract-version@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/ci-tools/commit/afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad

- `dfinity/ci-tools/actions/assemble-docs@main` -> `dfinity/ci-tools/actions/assemble-docs@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/ci-tools/commit/afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad

- `dfinity/ci-tools/actions/submit-docs@main` -> `dfinity/ci-tools/actions/submit-docs@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/ci-tools/commit/afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad

- `dfinity/setup-dfx@main` -> `dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/setup-dfx/commit/e50c04f104ee4285ec010f10609483cf41e4d365

- `peter-evans/create-pull-request@v7` -> `peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11`
  - Version: v7.0.11 | Latest: v8.1.0 | Release age: 77d
  - Commit: https://github.com/peter-evans/create-pull-request/commit/22a9089034f40e5a961c8808d113e2c98fb63676


### Files modified

- `.github/workflows/checks.yml`
- `.github/workflows/docs.yml`
- `.github/workflows/publish-docs.yml`
- `.github/workflows/tests-integration.yml`
- `.github/workflows/update-ic.yml`