### PR TITLE
chore(ci): pin and bump actions/setup-node

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -5,7 +5,7 @@ description: Checkout and install dependencies
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: 25
         registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
# Motivation

Leftover of #1506: similarly as in the referenced PR, we also want to pin the actions used in composites.

# Changes

- Bump (since I was already there) and pin `actions/setup-node` [v6.3.0](https://github.com/actions/setup-node/releases/tag/v6.3.0)