### PR TITLE
feat(nns): expose eightYearGangBonusBaseE8s on NeuronInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Features
+
+- NNS: expose `eightYearGangBonusBaseE8s` on the `NeuronInfo` converter type and map it in `toNeuronInfo` (the field was previously only wired for `Neuron`).
+
 ### Chore
 
 - Add support for patch releases with dedicated publish workflow and scripts.

--- a/packages/canisters/src/nns/canisters/governance/response.converters.spec.ts
+++ b/packages/canisters/src/nns/canisters/governance/response.converters.spec.ts
@@ -127,6 +127,7 @@ describe("response.converters", () => {
     votingPowerRefreshedTimestampSeconds: undefined,
     decidingVotingPower: undefined,
     potentialVotingPower: undefined,
+    eightYearGangBonusBaseE8s: 32n,
     ageSeconds: 0n,
     fullNeuron: undefined,
     visibility: undefined,
@@ -269,6 +270,36 @@ describe("response.converters", () => {
           canisterId,
         }),
       ).toEqual({ ...defaultNeuronInfo, decidingVotingPower });
+    });
+
+    it("should convert eight year gang bonus base e8s", () => {
+      const eightYearGangBonusBaseE8s = 777n;
+
+      expect(
+        toNeuronInfo({
+          neuronId,
+          neuronInfo: {
+            ...defaultCandidNeuronInfo,
+            eight_year_gang_bonus_base_e8s: [eightYearGangBonusBaseE8s],
+          },
+          rawNeuron: undefined,
+          canisterId,
+        }),
+      ).toEqual({ ...defaultNeuronInfo, eightYearGangBonusBaseE8s });
+    });
+
+    it("should convert missing eight year gang bonus base e8s to undefined", () => {
+      expect(
+        toNeuronInfo({
+          neuronId,
+          neuronInfo: {
+            ...defaultCandidNeuronInfo,
+            eight_year_gang_bonus_base_e8s: [],
+          },
+          rawNeuron: undefined,
+          canisterId,
+        }),
+      ).toEqual({ ...defaultNeuronInfo, eightYearGangBonusBaseE8s: undefined });
     });
   });
 

--- a/packages/canisters/src/nns/canisters/governance/response.converters.ts
+++ b/packages/canisters/src/nns/canisters/governance/response.converters.ts
@@ -111,6 +111,9 @@ export const toNeuronInfo = ({
     ),
     decidingVotingPower: fromNullable(neuronInfo.deciding_voting_power),
     potentialVotingPower: fromNullable(neuronInfo.potential_voting_power),
+    eightYearGangBonusBaseE8s: fromNullable(
+      neuronInfo.eight_year_gang_bonus_base_e8s,
+    ),
     ageSeconds: neuronInfo.age_seconds,
     visibility: fromNullable(neuronInfo.visibility) as
       | NeuronVisibility

--- a/packages/canisters/src/nns/types/governance_converters.ts
+++ b/packages/canisters/src/nns/types/governance_converters.ts
@@ -494,6 +494,7 @@ export interface NeuronInfo {
   votingPowerRefreshedTimestampSeconds: Option<bigint>;
   decidingVotingPower: Option<bigint>;
   potentialVotingPower: Option<bigint>;
+  eightYearGangBonusBaseE8s: Option<bigint>;
   ageSeconds: bigint;
   fullNeuron: Option<Neuron>;
   visibility: Option<NeuronVisibility>;


### PR DESCRIPTION
# Motivation

The 8Y gang bonus field was wired on `Neuron` in #1513 but the analogous field on `NeuronInfo` (already present in the backend Candid and populated by `get_neuron_info`) was not mapped. Consumers reading `NeuronInfo` without a `fullNeuron` currently don't see the bonus.

# Changes

- Add `eightYearGangBonusBaseE8s: Option<bigint>` to the `NeuronInfo` interface.
- Map `neuronInfo.eight_year_gang_bonus_base_e8s` via `fromNullable` in `toNeuronInfo`.
- Update `defaultNeuronInfo` in the response converter spec and add two focused tests (happy path + missing/undefined).

# Tests

- `npm test -w packages/canisters` — 742 passing.
- `npx tsc --project tsconfig.spec.json --noEmit` — clean.
- Built `.d.ts` includes the field on both `Neuron` and `NeuronInfo`.

# Todos

- [x] Add entry to changelog (if necessary).