### PR TITLE
chore(docs): reduce amount of docs files generated

### DIFF
--- a/docs/typedoc.json
+++ b/docs/typedoc.json
@@ -30,9 +30,7 @@
       "path": "src/content/docs"
     }
   ],
-  "projectDocuments": [
-    "../CHANGELOG.md"
-  ],
+  "projectDocuments": ["../CHANGELOG.md"],
   "router": "module",
   "entryFileName": "index",
   "hidePageTitle": true,

--- a/docs/typedoc.json
+++ b/docs/typedoc.json
@@ -21,10 +21,19 @@
     "@dfinity/typedoc-plugin-icp-docs"
   ],
   "outputs": [
-    { "name": "markdown", "path": "src/content/tmp" },
-    { "name": "icp-docs", "path": "src/content/docs" }
+    {
+      "name": "markdown",
+      "path": "src/content/tmp"
+    },
+    {
+      "name": "icp-docs",
+      "path": "src/content/docs"
+    }
   ],
-  "projectDocuments": ["../CHANGELOG.md"],
+  "projectDocuments": [
+    "../CHANGELOG.md"
+  ],
+  "router": "module",
   "entryFileName": "index",
   "hidePageTitle": true,
   "hideBreadcrumbs": true,


### PR DESCRIPTION
The JS docs are getting bloated. The assets generated are 2.7GB by now, and most of the size comes from here:
```
❯ du -sh docs/dist/canisters/*/
940M	docs/dist/canisters/latest/
119M	docs/dist/canisters/v2/
928M	docs/dist/canisters/v3/
```

Since every files has a fixed overhead, the number of files matters a lot:
```
❯ for d in docs/dist/*/*/; do echo "$(find "$d" -name '*.md' | wc -l) $d"; done | sort -rn
    1778 docs/dist/canisters/v3/
    1778 docs/dist/canisters/latest/
     567 docs/dist/canisters/v2/
     411 docs/dist/core/v5.3/
     411 docs/dist/core/latest/
         ...
```

With this PR, the number of files generated goes from 1.8k down to ~30. Instead of generating 1 file per exported symbol it generates 1 file per source file