### PR TITLE
chore(ci): close superseded IC update PRs

### DIFF
--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -66,6 +66,7 @@ jobs:
             echo "updated=1" >> "$GITHUB_OUTPUT"
           fi
       - name: Create Pull Request
+        id: create_pull_request
         if: ${{ steps.update.outputs.updated == '1' }}
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
@@ -92,3 +93,37 @@ jobs:
 
             # Tests
               - [ ] Please check the API updates for any breaking changes that affect our code.
+      - name: Close previous IC update pull requests
+        if: ${{ steps.update.outputs.updated == '1' && steps.create_pull_request.outputs.pull-request-number != '' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          NEW_PR_NUMBER: ${{ steps.create_pull_request.outputs.pull-request-number }}
+          PR_BRANCH_PREFIX: bot-ic-update
+          PR_TITLE: 'feat(core): Update Candid Files'
+          REPO: ${{ github.repository }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t previous_prs < <(
+            gh pr list \
+              --repo "$REPO" \
+              --state open \
+              --limit 200 \
+              --json number,title,headRefName,headRepositoryOwner \
+              --jq '.[] | select(.number != (env.NEW_PR_NUMBER | tonumber) and .title == env.PR_TITLE and (.headRefName | startswith(env.PR_BRANCH_PREFIX)) and .headRepositoryOwner.login == env.REPO_OWNER) | [.number, .headRefName] | @tsv'
+          )
+
+          if [[ "${#previous_prs[@]}" -eq 0 ]]; then
+            echo "No previous IC update pull requests to close."
+            exit 0
+          fi
+
+          close_comment="Closing this superseded automated IC Candid update PR because workflow run ${RUN_URL} opened PR #${NEW_PR_NUMBER} as a fresh replacement. The new PR contains the latest generated Candid files and bindings, so keeping older generated PRs open creates duplicate review work."
+
+          for pr in "${previous_prs[@]}"; do
+            IFS=$'\t' read -r number branch <<< "$pr"
+            echo "Closing PR #${number} (${branch}) and deleting its branch."
+            gh pr close "$number" --repo "$REPO" --delete-branch --comment "$close_comment"
+          done

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -106,19 +106,23 @@ jobs:
         run: |
           set -euo pipefail
 
-          mapfile -t previous_prs < <(
+          # Run gh separately so a failure (auth, rate limit) aborts the step
+          # instead of being swallowed by process substitution.
+          previous_prs_tsv="$(
             gh pr list \
               --repo "$REPO" \
               --state open \
               --limit 200 \
               --json number,title,headRefName,headRepositoryOwner \
               --jq '.[] | select(.number != (env.NEW_PR_NUMBER | tonumber) and .title == env.PR_TITLE and (.headRefName | startswith(env.PR_BRANCH_PREFIX)) and .headRepositoryOwner.login == env.REPO_OWNER) | [.number, .headRefName] | @tsv'
-          )
+          )"
 
-          if [[ "${#previous_prs[@]}" -eq 0 ]]; then
+          if [[ -z "$previous_prs_tsv" ]]; then
             echo "No previous IC update pull requests to close."
             exit 0
           fi
+
+          mapfile -t previous_prs <<< "$previous_prs_tsv"
 
           close_comment="Closing this superseded automated IC Candid update PR because workflow run ${RUN_URL} opened PR #${NEW_PR_NUMBER} as a fresh replacement. The new PR contains the latest generated Candid files and bindings, so keeping older generated PRs open creates duplicate review work."
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Motivation

The scheduled IC Candid update workflow currently creates timestamped branches, which can leave several generated update PRs open at the same time. GitHub PRs cannot be deleted, so superseded automation PRs should be closed with an explanation and their branches removed.

# Changes

- Give the create-pull-request step an ID so the workflow can identify the fresh PR it just opened.
- Add a cleanup step that lists open generated IC update PRs, excludes the newly created PR, closes older matching PRs with a superseded-by-run comment, and deletes their branches.

# Tests

- [x] `git diff --check`
- [x] `npm exec -- prettier --check .github/workflows/update-ic.yml`
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/update-ic.yml`
- [x] Read-only `gh pr list` query validated the filter matches older generated PRs while excluding a supplied new PR number.

# Todos

- [ ] Add entry to changelog (if necessary).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ca8ec1a-b11b-4ed6-94ad-fb942b3642f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ca8ec1a-b11b-4ed6-94ad-fb942b3642f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

