### PR TITLE
feat(core): Update Candid Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+### Features
+
+- Update latest Candid files.
+- NNS: support the new `vcpuType` field on `GuestLaunchMeasurement` metadata, wired through the `BlessAlternativeGuestOsVersion` proposal request and response converters.
+
 ## 97
 
 ### Overview

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     {
       "name": "@dfinity/ckbtc",
       "path": "./packages/ckbtc/dist/index.js",
-      "limit": "9 kB",
+      "limit": "10 kB",
       "gzip": true,
       "ignore": [
         "@dfinity/agent",
@@ -206,7 +206,7 @@
     {
       "name": "@icp-sdk/canisters/ckbtc",
       "path": "./packages/canisters/ckbtc/index.js",
-      "limit": "9 kB",
+      "limit": "10 kB",
       "gzip": true,
       "ignore": [
         "@dfinity/agent",

--- a/packages/canisters/src/declarations/ckbtc/minter.certified.idl.js
+++ b/packages/canisters/src/declarations/ckbtc/minter.certified.idl.js
@@ -300,6 +300,59 @@ export const idlFactory = ({ IDL }) => {
     min_confirmations: IDL.Nat32,
     kyt_fee: IDL.Nat64,
   });
+  const Icrc10StandardRecord = IDL.Record({
+    url: IDL.Text,
+    name: IDL.Text,
+  });
+  const Icrc21ConsentMessageMetadata = IDL.Record({
+    utc_offset_minutes: IDL.Opt(IDL.Int16),
+    language: IDL.Text,
+  });
+  const Icrc21DeviceSpec = IDL.Variant({
+    GenericDisplay: IDL.Null,
+    FieldsDisplay: IDL.Null,
+  });
+  const Icrc21ConsentMessageSpec = IDL.Record({
+    metadata: Icrc21ConsentMessageMetadata,
+    device_spec: IDL.Opt(Icrc21DeviceSpec),
+  });
+  const Icrc21ConsentMessageRequest = IDL.Record({
+    arg: IDL.Vec(IDL.Nat8),
+    method: IDL.Text,
+    user_preferences: Icrc21ConsentMessageSpec,
+  });
+  const Icrc21Value = IDL.Variant({
+    Text: IDL.Record({ content: IDL.Text }),
+    TokenAmount: IDL.Record({
+      decimals: IDL.Nat8,
+      amount: IDL.Nat64,
+      symbol: IDL.Text,
+    }),
+    TimestampSeconds: IDL.Record({ amount: IDL.Nat64 }),
+    DurationSeconds: IDL.Record({ amount: IDL.Nat64 }),
+  });
+  const Icrc21FieldsDisplay = IDL.Record({
+    fields: IDL.Vec(IDL.Tuple(IDL.Text, Icrc21Value)),
+    intent: IDL.Text,
+  });
+  const Icrc21ConsentMessage = IDL.Variant({
+    FieldsDisplayMessage: Icrc21FieldsDisplay,
+    GenericDisplayMessage: IDL.Text,
+  });
+  const Icrc21ConsentInfo = IDL.Record({
+    metadata: Icrc21ConsentMessageMetadata,
+    consent_message: Icrc21ConsentMessage,
+  });
+  const Icrc21ErrorInfo = IDL.Record({ description: IDL.Text });
+  const Icrc21Error = IDL.Variant({
+    GenericError: IDL.Record({
+      description: IDL.Text,
+      error_code: IDL.Nat,
+    }),
+    InsufficientPayment: Icrc21ErrorInfo,
+    UnsupportedCanisterCall: Icrc21ErrorInfo,
+    ConsentMessageUnavailable: Icrc21ErrorInfo,
+  });
   const RetrieveBtcArgs = IDL.Record({
     address: IDL.Text,
     amount: IDL.Nat64,
@@ -440,6 +493,16 @@ export const idlFactory = ({ IDL }) => {
     ),
     get_minter_info: IDL.Func([], [MinterInfo], []),
     get_withdrawal_account: IDL.Func([], [Account], []),
+    icrc10_supported_standards: IDL.Func(
+      [],
+      [IDL.Vec(Icrc10StandardRecord)],
+      [],
+    ),
+    icrc21_canister_call_consent_message: IDL.Func(
+      [Icrc21ConsentMessageRequest],
+      [IDL.Variant({ Ok: Icrc21ConsentInfo, Err: Icrc21Error })],
+      [],
+    ),
     retrieve_btc: IDL.Func(
       [RetrieveBtcArgs],
       [IDL.Variant({ Ok: RetrieveBtcOk, Err: RetrieveBtcError })],

--- a/packages/canisters/src/declarations/ckbtc/minter.d.ts
+++ b/packages/canisters/src/declarations/ckbtc/minter.d.ts
@@ -272,6 +272,66 @@ export type EventType =
       };
     };
 /**
+ * ICRC-10 supported standards record.
+ */
+export interface Icrc10StandardRecord {
+  url: string;
+  name: string;
+}
+export interface Icrc21ConsentInfo {
+  metadata: Icrc21ConsentMessageMetadata;
+  consent_message: Icrc21ConsentMessage;
+}
+export type Icrc21ConsentMessage =
+  | {
+      FieldsDisplayMessage: Icrc21FieldsDisplay;
+    }
+  | { GenericDisplayMessage: string };
+/**
+ * ICRC-21 Canister Call Consent Message types.
+ */
+export interface Icrc21ConsentMessageMetadata {
+  utc_offset_minutes: [] | [number];
+  language: string;
+}
+export interface Icrc21ConsentMessageRequest {
+  arg: Uint8Array;
+  method: string;
+  user_preferences: Icrc21ConsentMessageSpec;
+}
+export interface Icrc21ConsentMessageSpec {
+  metadata: Icrc21ConsentMessageMetadata;
+  device_spec: [] | [Icrc21DeviceSpec];
+}
+export type Icrc21DeviceSpec =
+  | { GenericDisplay: null }
+  | { FieldsDisplay: null };
+export type Icrc21Error =
+  | {
+      GenericError: { description: string; error_code: bigint };
+    }
+  | { InsufficientPayment: Icrc21ErrorInfo }
+  | { UnsupportedCanisterCall: Icrc21ErrorInfo }
+  | { ConsentMessageUnavailable: Icrc21ErrorInfo };
+export interface Icrc21ErrorInfo {
+  description: string;
+}
+export interface Icrc21FieldsDisplay {
+  fields: Array<[string, Icrc21Value]>;
+  intent: string;
+}
+export type Icrc21Value =
+  | { Text: { content: string } }
+  | {
+      TokenAmount: {
+        decimals: number;
+        amount: bigint;
+        symbol: string;
+      };
+    }
+  | { TimestampSeconds: { amount: bigint } }
+  | { DurationSeconds: { amount: bigint } };
+/**
  * The initialization parameters of the minter canister.
  */
 export interface InitArgs {
@@ -960,6 +1020,19 @@ export interface _SERVICE {
    * before withdrawing BTC using the [retrieve_btc] endpoint.
    */
   get_withdrawal_account: ActorMethod<[], Account>;
+  /**
+   * Returns the list of supported ICRC standards.
+   */
+  icrc10_supported_standards: ActorMethod<[], Array<Icrc10StandardRecord>>;
+  /**
+   * Returns a human-readable consent message describing the requested
+   * canister call. See the ICRC-21 standard for details:
+   * https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-21/ICRC-21.md
+   */
+  icrc21_canister_call_consent_message: ActorMethod<
+    [Icrc21ConsentMessageRequest],
+    { Ok: Icrc21ConsentInfo } | { Err: Icrc21Error }
+  >;
   /**
    * Submits a request to convert ckBTC to BTC.
    *

--- a/packages/canisters/src/declarations/ckbtc/minter.did
+++ b/packages/canisters/src/declarations/ckbtc/minter.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 606cab7 (2026-04-01 tags: release-2026-04-02_04-48-base) 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
+// Generated from IC repo commit 93274f1 (2026-06-15 tags: release-2026-06-12_04-52-hotfix) 'rs/bitcoin/ckbtc/minter/ckbtc_minter.did' by import-candid
 
 // Represents an account on the ckBTC ledger.
 type Account = record { owner : principal; subaccount : opt blob };
@@ -613,7 +613,70 @@ type DecodeLedgerMemoResult = variant {
     // An error in case the minter was not able to decode the provided memo. This field is `opt`, so that other error
     // types can be added in the future.
     Err : opt DecodeLedgerMemoError;
-}
+};
+
+// ICRC-10 supported standards record.
+type Icrc10StandardRecord = record {
+    name : text;
+    url : text;
+};
+
+// ICRC-21 Canister Call Consent Message types.
+type Icrc21ConsentMessageMetadata = record {
+    language : text;
+    utc_offset_minutes : opt int16;
+};
+
+type Icrc21DeviceSpec = variant {
+    GenericDisplay;
+    FieldsDisplay;
+};
+
+type Icrc21ConsentMessageSpec = record {
+    metadata : Icrc21ConsentMessageMetadata;
+    device_spec : opt Icrc21DeviceSpec;
+};
+
+type Icrc21ConsentMessageRequest = record {
+    method : text;
+    arg : blob;
+    user_preferences : Icrc21ConsentMessageSpec;
+};
+
+type Icrc21Value = variant {
+    TokenAmount : record {
+        decimals : nat8;
+        amount : nat64;
+        symbol : text;
+    };
+    TimestampSeconds : record { amount : nat64 };
+    DurationSeconds : record { amount : nat64 };
+    Text : record { content : text };
+};
+
+type Icrc21FieldsDisplay = record {
+    intent : text;
+    fields : vec record { text; Icrc21Value };
+};
+
+type Icrc21ConsentMessage = variant {
+    GenericDisplayMessage : text;
+    FieldsDisplayMessage : Icrc21FieldsDisplay;
+};
+
+type Icrc21ConsentInfo = record {
+    consent_message : Icrc21ConsentMessage;
+    metadata : Icrc21ConsentMessageMetadata;
+};
+
+type Icrc21ErrorInfo = record { description : text };
+
+type Icrc21Error = variant {
+    UnsupportedCanisterCall : Icrc21ErrorInfo;
+    ConsentMessageUnavailable : Icrc21ErrorInfo;
+    InsufficientPayment : Icrc21ErrorInfo;
+    GenericError : record { error_code : nat; description : text };
+};
 
 service : (minter_arg : MinterArg) -> {
     // Section "Convert BTC to ckBTC" {{{
@@ -730,4 +793,16 @@ service : (minter_arg : MinterArg) -> {
     // Returns information related to minter transactions.
     decode_ledger_memo : (DecodeLedgerMemoArgs) -> (DecodeLedgerMemoResult) query;
     // }}}
+
+    // Section "ICRC-10 / ICRC-21" {{{
+
+    // Returns the list of supported ICRC standards.
+    icrc10_supported_standards : () -> (vec Icrc10StandardRecord) query;
+
+    // Returns a human-readable consent message describing the requested
+    // canister call. See the ICRC-21 standard for details:
+    // https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-21/ICRC-21.md
+    icrc21_canister_call_consent_message : (Icrc21ConsentMessageRequest) -> (variant { Ok : Icrc21ConsentInfo; Err : Icrc21Error });
+
+    // }}} Section "ICRC-10 / ICRC-21"
 }

--- a/packages/canisters/src/declarations/ckbtc/minter.idl.js
+++ b/packages/canisters/src/declarations/ckbtc/minter.idl.js
@@ -300,6 +300,59 @@ export const idlFactory = ({ IDL }) => {
     min_confirmations: IDL.Nat32,
     kyt_fee: IDL.Nat64,
   });
+  const Icrc10StandardRecord = IDL.Record({
+    url: IDL.Text,
+    name: IDL.Text,
+  });
+  const Icrc21ConsentMessageMetadata = IDL.Record({
+    utc_offset_minutes: IDL.Opt(IDL.Int16),
+    language: IDL.Text,
+  });
+  const Icrc21DeviceSpec = IDL.Variant({
+    GenericDisplay: IDL.Null,
+    FieldsDisplay: IDL.Null,
+  });
+  const Icrc21ConsentMessageSpec = IDL.Record({
+    metadata: Icrc21ConsentMessageMetadata,
+    device_spec: IDL.Opt(Icrc21DeviceSpec),
+  });
+  const Icrc21ConsentMessageRequest = IDL.Record({
+    arg: IDL.Vec(IDL.Nat8),
+    method: IDL.Text,
+    user_preferences: Icrc21ConsentMessageSpec,
+  });
+  const Icrc21Value = IDL.Variant({
+    Text: IDL.Record({ content: IDL.Text }),
+    TokenAmount: IDL.Record({
+      decimals: IDL.Nat8,
+      amount: IDL.Nat64,
+      symbol: IDL.Text,
+    }),
+    TimestampSeconds: IDL.Record({ amount: IDL.Nat64 }),
+    DurationSeconds: IDL.Record({ amount: IDL.Nat64 }),
+  });
+  const Icrc21FieldsDisplay = IDL.Record({
+    fields: IDL.Vec(IDL.Tuple(IDL.Text, Icrc21Value)),
+    intent: IDL.Text,
+  });
+  const Icrc21ConsentMessage = IDL.Variant({
+    FieldsDisplayMessage: Icrc21FieldsDisplay,
+    GenericDisplayMessage: IDL.Text,
+  });
+  const Icrc21ConsentInfo = IDL.Record({
+    metadata: Icrc21ConsentMessageMetadata,
+    consent_message: Icrc21ConsentMessage,
+  });
+  const Icrc21ErrorInfo = IDL.Record({ description: IDL.Text });
+  const Icrc21Error = IDL.Variant({
+    GenericError: IDL.Record({
+      description: IDL.Text,
+      error_code: IDL.Nat,
+    }),
+    InsufficientPayment: Icrc21ErrorInfo,
+    UnsupportedCanisterCall: Icrc21ErrorInfo,
+    ConsentMessageUnavailable: Icrc21ErrorInfo,
+  });
   const RetrieveBtcArgs = IDL.Record({
     address: IDL.Text,
     amount: IDL.Nat64,
@@ -440,6 +493,16 @@ export const idlFactory = ({ IDL }) => {
     ),
     get_minter_info: IDL.Func([], [MinterInfo], ["query"]),
     get_withdrawal_account: IDL.Func([], [Account], []),
+    icrc10_supported_standards: IDL.Func(
+      [],
+      [IDL.Vec(Icrc10StandardRecord)],
+      ["query"],
+    ),
+    icrc21_canister_call_consent_message: IDL.Func(
+      [Icrc21ConsentMessageRequest],
+      [IDL.Variant({ Ok: Icrc21ConsentInfo, Err: Icrc21Error })],
+      [],
+    ),
     retrieve_btc: IDL.Func(
       [RetrieveBtcArgs],
       [IDL.Variant({ Ok: RetrieveBtcOk, Err: RetrieveBtcError })],

--- a/packages/canisters/src/declarations/cketh/minter.certified.idl.js
+++ b/packages/canisters/src/declarations/cketh/minter.certified.idl.js
@@ -97,10 +97,24 @@ export const idlFactory = ({ IDL }) => {
     timestamp: IDL.Opt(IDL.Nat64),
     gas_limit: IDL.Nat,
   });
+  const MemoryMetrics = IDL.Record({
+    wasm_binary_size: IDL.Nat,
+    wasm_chunk_store_size: IDL.Nat,
+    canister_history_size: IDL.Nat,
+    stable_memory_size: IDL.Nat,
+    snapshots_size: IDL.Nat,
+    wasm_memory_size: IDL.Nat,
+    global_memory_size: IDL.Nat,
+    custom_sections_size: IDL.Nat,
+  });
   const CanisterStatusType = IDL.Variant({
     stopped: IDL.Null,
     stopping: IDL.Null,
     running: IDL.Null,
+  });
+  const environment_variable = IDL.Record({
+    value: IDL.Text,
+    name: IDL.Text,
   });
   const LogVisibility = IDL.Variant({
     controllers: IDL.Null,
@@ -109,6 +123,8 @@ export const idlFactory = ({ IDL }) => {
   });
   const DefiniteCanisterSettings = IDL.Record({
     freezing_threshold: IDL.Nat,
+    wasm_memory_threshold: IDL.Nat,
+    environment_variables: IDL.Vec(environment_variable),
     controllers: IDL.Vec(IDL.Principal),
     reserved_cycles_limit: IDL.Nat,
     log_visibility: LogVisibility,
@@ -123,8 +139,11 @@ export const idlFactory = ({ IDL }) => {
     request_payload_bytes_total: IDL.Nat,
   });
   const CanisterStatusResponse = IDL.Record({
+    memory_metrics: MemoryMetrics,
     status: CanisterStatusType,
     memory_size: IDL.Nat,
+    ready_for_migration: IDL.Bool,
+    version: IDL.Nat64,
     cycles: IDL.Nat,
     settings: DefiniteCanisterSettings,
     query_stats: QueryStats,

--- a/packages/canisters/src/declarations/cketh/minter.d.ts
+++ b/packages/canisters/src/declarations/cketh/minter.d.ts
@@ -102,8 +102,11 @@ export type BurnMemo =
       };
     };
 export interface CanisterStatusResponse {
+  memory_metrics: MemoryMetrics;
   status: CanisterStatusType;
   memory_size: bigint;
+  ready_for_migration: boolean;
+  version: bigint;
   cycles: bigint;
   settings: DefiniteCanisterSettings;
   query_stats: QueryStats;
@@ -166,6 +169,8 @@ export type DecodedMemo =
     };
 export interface DefiniteCanisterSettings {
   freezing_threshold: bigint;
+  wasm_memory_threshold: bigint;
+  environment_variables: Array<environment_variable>;
   controllers: Array<Principal>;
   reserved_cycles_limit: bigint;
   log_visibility: LogVisibility;
@@ -482,6 +487,16 @@ export type LogVisibility =
   | { public: null }
   | { allowed_viewers: Array<Principal> };
 export type MemoType = { Burn: null } | { Mint: null };
+export interface MemoryMetrics {
+  wasm_binary_size: bigint;
+  wasm_chunk_store_size: bigint;
+  canister_history_size: bigint;
+  stable_memory_size: bigint;
+  snapshots_size: bigint;
+  wasm_memory_size: bigint;
+  global_memory_size: bigint;
+  custom_sections_size: bigint;
+}
 export type MintMemo =
   | {
       /**
@@ -956,6 +971,10 @@ export type WithdrawalStatus =
        */
       Pending: null;
     };
+export interface environment_variable {
+  value: string;
+  name: string;
+}
 export interface _SERVICE {
   /**
    * Add a ckERC-20 token to be supported by the minter.
@@ -978,6 +997,8 @@ export interface _SERVICE {
   >;
   /**
    * Retrieve the status of the minter canister.
+   *
+   * This is a debug endpoint where backwards-compatibility is not guaranteed.
    */
   get_canister_status: ActorMethod<[], CanisterStatusResponse>;
   /**

--- a/packages/canisters/src/declarations/cketh/minter.did
+++ b/packages/canisters/src/declarations/cketh/minter.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 606cab7 (2026-04-01 tags: release-2026-04-02_04-48-base) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
+// Generated from IC repo commit 93274f1 (2026-06-15 tags: release-2026-06-12_04-52-hotfix) 'rs/ethereum/cketh/minter/cketh_minter.did' by import-candid
 
 type EthereumNetwork = variant {
     // The public Ethereum mainnet.
@@ -9,18 +9,37 @@ type EthereumNetwork = variant {
 
 type Subaccount = blob;
 
+type environment_variable = record {
+    name: text;
+    value: text;
+};
+
 type CanisterStatusResponse = record {
-  query_stats : QueryStats;
   status : CanisterStatusType;
+  ready_for_migration : bool;
+  version : nat64;
   memory_size : nat;
   cycles : nat;
   settings : DefiniteCanisterSettings;
   idle_cycles_burned_per_day : nat;
   module_hash : opt vec nat8;
+  query_stats : QueryStats;
   reserved_cycles : nat;
+  memory_metrics : MemoryMetrics;
 };
 
 type CanisterStatusType = variant { stopped; stopping; running };
+
+type MemoryMetrics = record {
+    wasm_memory_size : nat;
+    stable_memory_size : nat;
+    global_memory_size : nat;
+    wasm_binary_size : nat;
+    custom_sections_size : nat;
+    canister_history_size : nat;
+    wasm_chunk_store_size : nat;
+    snapshots_size : nat;
+};
 
 type DefiniteCanisterSettings = record {
   freezing_threshold : nat;
@@ -30,6 +49,8 @@ type DefiniteCanisterSettings = record {
   reserved_cycles_limit : nat;
   log_visibility: LogVisibility;
   wasm_memory_limit : nat;
+  wasm_memory_threshold : nat;
+  environment_variables : vec environment_variable;
 };
 
 type LogVisibility = variant {
@@ -713,6 +734,8 @@ service : (MinterArg) -> {
     is_address_blocked : (text) -> (bool) query;
 
     // Retrieve the status of the minter canister.
+    //
+    // This is a debug endpoint where backwards-compatibility is not guaranteed.
     get_canister_status : () -> (CanisterStatusResponse);
 
     // Retrieve events from the minter's audit log.

--- a/packages/canisters/src/declarations/cketh/minter.idl.js
+++ b/packages/canisters/src/declarations/cketh/minter.idl.js
@@ -97,10 +97,24 @@ export const idlFactory = ({ IDL }) => {
     timestamp: IDL.Opt(IDL.Nat64),
     gas_limit: IDL.Nat,
   });
+  const MemoryMetrics = IDL.Record({
+    wasm_binary_size: IDL.Nat,
+    wasm_chunk_store_size: IDL.Nat,
+    canister_history_size: IDL.Nat,
+    stable_memory_size: IDL.Nat,
+    snapshots_size: IDL.Nat,
+    wasm_memory_size: IDL.Nat,
+    global_memory_size: IDL.Nat,
+    custom_sections_size: IDL.Nat,
+  });
   const CanisterStatusType = IDL.Variant({
     stopped: IDL.Null,
     stopping: IDL.Null,
     running: IDL.Null,
+  });
+  const environment_variable = IDL.Record({
+    value: IDL.Text,
+    name: IDL.Text,
   });
   const LogVisibility = IDL.Variant({
     controllers: IDL.Null,
@@ -109,6 +123,8 @@ export const idlFactory = ({ IDL }) => {
   });
   const DefiniteCanisterSettings = IDL.Record({
     freezing_threshold: IDL.Nat,
+    wasm_memory_threshold: IDL.Nat,
+    environment_variables: IDL.Vec(environment_variable),
     controllers: IDL.Vec(IDL.Principal),
     reserved_cycles_limit: IDL.Nat,
     log_visibility: LogVisibility,
@@ -123,8 +139,11 @@ export const idlFactory = ({ IDL }) => {
     request_payload_bytes_total: IDL.Nat,
   });
   const CanisterStatusResponse = IDL.Record({
+    memory_metrics: MemoryMetrics,
     status: CanisterStatusType,
     memory_size: IDL.Nat,
+    ready_for_migration: IDL.Bool,
+    version: IDL.Nat64,
     cycles: IDL.Nat,
     settings: DefiniteCanisterSettings,
     query_stats: QueryStats,

--- a/packages/canisters/src/declarations/cketh/orchestrator.certified.idl.js
+++ b/packages/canisters/src/declarations/cketh/orchestrator.certified.idl.js
@@ -67,10 +67,24 @@ export const idlFactory = ({ IDL }) => {
     index: IDL.Opt(IDL.Principal),
     archives: IDL.Vec(IDL.Principal),
   });
+  const MemoryMetrics = IDL.Record({
+    wasm_binary_size: IDL.Nat,
+    wasm_chunk_store_size: IDL.Nat,
+    canister_history_size: IDL.Nat,
+    stable_memory_size: IDL.Nat,
+    snapshots_size: IDL.Nat,
+    wasm_memory_size: IDL.Nat,
+    global_memory_size: IDL.Nat,
+    custom_sections_size: IDL.Nat,
+  });
   const CanisterStatusType = IDL.Variant({
     stopped: IDL.Null,
     stopping: IDL.Null,
     running: IDL.Null,
+  });
+  const environment_variable = IDL.Record({
+    value: IDL.Text,
+    name: IDL.Text,
   });
   const LogVisibility = IDL.Variant({
     controllers: IDL.Null,
@@ -79,6 +93,8 @@ export const idlFactory = ({ IDL }) => {
   });
   const DefiniteCanisterSettings = IDL.Record({
     freezing_threshold: IDL.Nat,
+    wasm_memory_threshold: IDL.Nat,
+    environment_variables: IDL.Vec(environment_variable),
     controllers: IDL.Vec(IDL.Principal),
     reserved_cycles_limit: IDL.Nat,
     log_visibility: LogVisibility,
@@ -93,8 +109,11 @@ export const idlFactory = ({ IDL }) => {
     request_payload_bytes_total: IDL.Nat,
   });
   const CanisterStatusResponse = IDL.Record({
+    memory_metrics: MemoryMetrics,
     status: CanisterStatusType,
     memory_size: IDL.Nat,
+    ready_for_migration: IDL.Bool,
+    version: IDL.Nat64,
     cycles: IDL.Nat,
     settings: DefiniteCanisterSettings,
     query_stats: QueryStats,

--- a/packages/canisters/src/declarations/cketh/orchestrator.d.ts
+++ b/packages/canisters/src/declarations/cketh/orchestrator.d.ts
@@ -15,8 +15,11 @@ export interface AddErc20Arg {
   ledger_init_arg: LedgerInitArg;
 }
 export interface CanisterStatusResponse {
+  memory_metrics: MemoryMetrics;
   status: CanisterStatusType;
   memory_size: bigint;
+  ready_for_migration: boolean;
+  version: bigint;
   cycles: bigint;
   settings: DefiniteCanisterSettings;
   query_stats: QueryStats;
@@ -48,6 +51,8 @@ export interface CyclesManagement {
 }
 export interface DefiniteCanisterSettings {
   freezing_threshold: bigint;
+  wasm_memory_threshold: bigint;
+  environment_variables: Array<environment_variable>;
   controllers: Array<Principal>;
   reserved_cycles_limit: bigint;
   log_visibility: LogVisibility;
@@ -190,6 +195,16 @@ export interface ManagedLedgerSuite {
    */
   archives: Array<Principal>;
 }
+export interface MemoryMetrics {
+  wasm_binary_size: bigint;
+  wasm_chunk_store_size: bigint;
+  canister_history_size: bigint;
+  stable_memory_size: bigint;
+  snapshots_size: bigint;
+  wasm_memory_size: bigint;
+  global_memory_size: bigint;
+  custom_sections_size: bigint;
+}
 export type OrchestratorArg =
   | { UpgradeArg: UpgradeArg }
   | { InitArg: InitArg }
@@ -288,6 +303,10 @@ export interface UpgradeArg {
    * Leaving this field empty will not upgrade the index canisters.
    */
   index_compressed_wasm_hash: [] | [string];
+}
+export interface environment_variable {
+  value: string;
+  name: string;
 }
 export interface _SERVICE {
   /**

--- a/packages/canisters/src/declarations/cketh/orchestrator.did
+++ b/packages/canisters/src/declarations/cketh/orchestrator.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 606cab7 (2026-04-01 tags: release-2026-04-02_04-48-base) 'rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did' by import-candid
+// Generated from IC repo commit 93274f1 (2026-06-15 tags: release-2026-06-12_04-52-hotfix) 'rs/ethereum/ledger-suite-orchestrator/ledger_suite_orchestrator.did' by import-candid
 
 type OrchestratorArg = variant {
     UpgradeArg : UpgradeArg;
@@ -208,18 +208,37 @@ type UpdateCyclesManagement = record {
    cycles_top_up_increment: opt nat;
 };
 
+type environment_variable = record {
+    name: text;
+    value: text;
+};
+
 type CanisterStatusResponse = record {
-  query_stats : QueryStats;
   status : CanisterStatusType;
+  ready_for_migration : bool;
+  version : nat64;
   memory_size : nat;
   cycles : nat;
   settings : DefiniteCanisterSettings;
   idle_cycles_burned_per_day : nat;
   module_hash : opt vec nat8;
+  query_stats : QueryStats;
   reserved_cycles : nat;
+  memory_metrics : MemoryMetrics;
 };
 
 type CanisterStatusType = variant { stopped; stopping; running };
+
+type MemoryMetrics = record {
+    wasm_memory_size : nat;
+    stable_memory_size : nat;
+    global_memory_size : nat;
+    wasm_binary_size : nat;
+    custom_sections_size : nat;
+    canister_history_size : nat;
+    wasm_chunk_store_size : nat;
+    snapshots_size : nat;
+};
 
 type DefiniteCanisterSettings = record {
   freezing_threshold : nat;
@@ -229,6 +248,8 @@ type DefiniteCanisterSettings = record {
   reserved_cycles_limit : nat;
   log_visibility: LogVisibility;
   wasm_memory_limit : nat;
+  wasm_memory_threshold : nat;
+  environment_variables : vec environment_variable;
 };
 
 type LogVisibility = variant {

--- a/packages/canisters/src/declarations/cketh/orchestrator.idl.js
+++ b/packages/canisters/src/declarations/cketh/orchestrator.idl.js
@@ -67,10 +67,24 @@ export const idlFactory = ({ IDL }) => {
     index: IDL.Opt(IDL.Principal),
     archives: IDL.Vec(IDL.Principal),
   });
+  const MemoryMetrics = IDL.Record({
+    wasm_binary_size: IDL.Nat,
+    wasm_chunk_store_size: IDL.Nat,
+    canister_history_size: IDL.Nat,
+    stable_memory_size: IDL.Nat,
+    snapshots_size: IDL.Nat,
+    wasm_memory_size: IDL.Nat,
+    global_memory_size: IDL.Nat,
+    custom_sections_size: IDL.Nat,
+  });
   const CanisterStatusType = IDL.Variant({
     stopped: IDL.Null,
     stopping: IDL.Null,
     running: IDL.Null,
+  });
+  const environment_variable = IDL.Record({
+    value: IDL.Text,
+    name: IDL.Text,
   });
   const LogVisibility = IDL.Variant({
     controllers: IDL.Null,
@@ -79,6 +93,8 @@ export const idlFactory = ({ IDL }) => {
   });
   const DefiniteCanisterSettings = IDL.Record({
     freezing_threshold: IDL.Nat,
+    wasm_memory_threshold: IDL.Nat,
+    environment_variables: IDL.Vec(environment_variable),
     controllers: IDL.Vec(IDL.Principal),
     reserved_cycles_limit: IDL.Nat,
     log_visibility: LogVisibility,
@@ -93,8 +109,11 @@ export const idlFactory = ({ IDL }) => {
     request_payload_bytes_total: IDL.Nat,
   });
   const CanisterStatusResponse = IDL.Record({
+    memory_metrics: MemoryMetrics,
     status: CanisterStatusType,
     memory_size: IDL.Nat,
+    ready_for_migration: IDL.Bool,
+    version: IDL.Nat64,
     cycles: IDL.Nat,
     settings: DefiniteCanisterSettings,
     query_stats: QueryStats,

--- a/packages/canisters/src/declarations/cmc/cmc.certified.idl.js
+++ b/packages/canisters/src/declarations/cmc/cmc.certified.idl.js
@@ -42,11 +42,6 @@ export const idlFactory = ({ IDL }) => {
     public: IDL.Null,
     allowed_viewers: IDL.Vec(IDL.Principal),
   });
-  const snapshot_visibility = IDL.Variant({
-    controllers: IDL.Null,
-    public: IDL.Null,
-    allowed_viewers: IDL.Vec(IDL.Principal),
-  });
   const CanisterSettings = IDL.Record({
     freezing_threshold: IDL.Opt(IDL.Nat),
     wasm_memory_threshold: IDL.Opt(IDL.Nat),
@@ -54,8 +49,6 @@ export const idlFactory = ({ IDL }) => {
     controllers: IDL.Opt(IDL.Vec(IDL.Principal)),
     reserved_cycles_limit: IDL.Opt(IDL.Nat),
     log_visibility: IDL.Opt(log_visibility),
-    log_memory_limit: IDL.Opt(IDL.Nat),
-    snapshot_visibility: IDL.Opt(snapshot_visibility),
     wasm_memory_limit: IDL.Opt(IDL.Nat),
     memory_allocation: IDL.Opt(IDL.Nat),
     compute_allocation: IDL.Opt(IDL.Nat),

--- a/packages/canisters/src/declarations/cmc/cmc.d.ts
+++ b/packages/canisters/src/declarations/cmc/cmc.d.ts
@@ -19,8 +19,6 @@ export interface CanisterSettings {
   controllers: [] | [Array<Principal>];
   reserved_cycles_limit: [] | [bigint];
   log_visibility: [] | [log_visibility];
-  log_memory_limit: [] | [bigint];
-  snapshot_visibility: [] | [snapshot_visibility];
   wasm_memory_limit: [] | [bigint];
   memory_allocation: [] | [bigint];
   compute_allocation: [] | [bigint];
@@ -294,10 +292,6 @@ export interface environment_variable {
   name: string;
 }
 export type log_visibility =
-  | { controllers: null }
-  | { public: null }
-  | { allowed_viewers: Array<Principal> };
-export type snapshot_visibility =
   | { controllers: null }
   | { public: null }
   | { allowed_viewers: Array<Principal> };

--- a/packages/canisters/src/declarations/cmc/cmc.did
+++ b/packages/canisters/src/declarations/cmc/cmc.did
@@ -1,13 +1,8 @@
-// Generated from IC repo commit 606cab7 (2026-04-01 tags: release-2026-04-02_04-48-base) 'rs/nns/cmc/cmc.did' by import-candid
+// Generated from IC repo commit 93274f1 (2026-06-15 tags: release-2026-06-12_04-52-hotfix) 'rs/nns/cmc/cmc.did' by import-candid
 
 type Cycles = nat;
 type BlockIndex = nat64;
 type log_visibility = variant {
-  controllers;
-  public;
-  allowed_viewers : vec principal;
-};
-type snapshot_visibility = variant {
   controllers;
   public;
   allowed_viewers : vec principal;
@@ -23,11 +18,9 @@ type CanisterSettings = record {
   freezing_threshold : opt nat;
   reserved_cycles_limit : opt nat;
   log_visibility : opt log_visibility;
-  snapshot_visibility : opt snapshot_visibility;
   wasm_memory_limit : opt nat;
   wasm_memory_threshold : opt nat;
   environment_variables : opt vec environment_variable;
-  log_memory_limit : opt nat;
 };
 type Subaccount = opt blob;
 type Memo = opt blob;

--- a/packages/canisters/src/declarations/cmc/cmc.idl.js
+++ b/packages/canisters/src/declarations/cmc/cmc.idl.js
@@ -42,11 +42,6 @@ export const idlFactory = ({ IDL }) => {
     public: IDL.Null,
     allowed_viewers: IDL.Vec(IDL.Principal),
   });
-  const snapshot_visibility = IDL.Variant({
-    controllers: IDL.Null,
-    public: IDL.Null,
-    allowed_viewers: IDL.Vec(IDL.Principal),
-  });
   const CanisterSettings = IDL.Record({
     freezing_threshold: IDL.Opt(IDL.Nat),
     wasm_memory_threshold: IDL.Opt(IDL.Nat),
@@ -54,8 +49,6 @@ export const idlFactory = ({ IDL }) => {
     controllers: IDL.Opt(IDL.Vec(IDL.Principal)),
     reserved_cycles_limit: IDL.Opt(IDL.Nat),
     log_visibility: IDL.Opt(log_visibility),
-    log_memory_limit: IDL.Opt(IDL.Nat),
-    snapshot_visibility: IDL.Opt(snapshot_visibility),
     wasm_memory_limit: IDL.Opt(IDL.Nat),
     memory_allocation: IDL.Opt(IDL.Nat),
     compute_allocation: IDL.Opt(IDL.Nat),

--- a/packages/canisters/src/declarations/ic-management/ic-management.certified.idl.js
+++ b/packages/canisters/src/declarations/ic-management/ic-management.certified.idl.js
@@ -135,6 +135,21 @@ export const idlFactory = ({ IDL }) => {
     canister_id: canister_id,
   });
   const canister_metadata_result = IDL.Record({ value: IDL.Vec(IDL.Nat8) });
+  const canister_metrics_args = IDL.Record({ canister_id: canister_id });
+  const cycles_consumed = IDL.Record({
+    memory: IDL.Nat,
+    canister_creation: IDL.Nat,
+    burned_cycles: IDL.Nat,
+    http_outcalls: IDL.Nat,
+    instructions: IDL.Nat,
+    uninstall: IDL.Nat,
+    ingress_induction: IDL.Nat,
+    request_and_response_transmission: IDL.Nat,
+    compute_allocation: IDL.Nat,
+  });
+  const canister_metrics_result = IDL.Record({
+    cycles_consumed: cycles_consumed,
+  });
   const canister_status_args = IDL.Record({ canister_id: canister_id });
   const environment_variable = IDL.Record({
     value: IDL.Text,
@@ -310,6 +325,13 @@ export const idlFactory = ({ IDL }) => {
     taken_at_timestamp: IDL.Nat64,
   });
   const list_canister_snapshots_result = IDL.Vec(snapshot);
+  const canister_id_range = IDL.Record({
+    end: canister_id,
+    start: canister_id,
+  });
+  const list_canisters_result = IDL.Record({
+    canisters: IDL.Vec(canister_id_range),
+  });
   const load_canister_snapshot_args = IDL.Record({
     canister_id: canister_id,
     sender_canister_version: IDL.Opt(IDL.Nat64),
@@ -553,6 +575,11 @@ export const idlFactory = ({ IDL }) => {
       [canister_metadata_result],
       [],
     ),
+    canister_metrics: IDL.Func(
+      [canister_metrics_args],
+      [canister_metrics_result],
+      [],
+    ),
     canister_status: IDL.Func(
       [canister_status_args],
       [canister_status_result],
@@ -585,6 +612,7 @@ export const idlFactory = ({ IDL }) => {
       [list_canister_snapshots_result],
       [],
     ),
+    list_canisters: IDL.Func([], [list_canisters_result], []),
     load_canister_snapshot: IDL.Func([load_canister_snapshot_args], [], []),
     node_metrics_history: IDL.Func(
       [node_metrics_history_args],

--- a/packages/canisters/src/declarations/ic-management/ic-management.d.ts
+++ b/packages/canisters/src/declarations/ic-management/ic-management.d.ts
@@ -50,6 +50,10 @@ export interface bitcoin_send_transaction_args {
   network: bitcoin_network;
 }
 export type canister_id = Principal;
+export interface canister_id_range {
+  end: canister_id;
+  start: canister_id;
+}
 export interface canister_info_args {
   canister_id: canister_id;
   num_requested_changes: [] | [bigint];
@@ -86,6 +90,12 @@ export interface canister_metadata_args {
 }
 export interface canister_metadata_result {
   value: Uint8Array;
+}
+export interface canister_metrics_args {
+  canister_id: canister_id;
+}
+export interface canister_metrics_result {
+  cycles_consumed: cycles_consumed;
 }
 export interface canister_settings {
   freezing_threshold: [] | [bigint];
@@ -192,6 +202,23 @@ export interface create_canister_args {
 export interface create_canister_result {
   canister_id: canister_id;
 }
+export interface cycles_consumed {
+  memory: bigint;
+  canister_creation: bigint;
+  burned_cycles: bigint;
+  http_outcalls: bigint;
+  instructions: bigint;
+  /**
+   * This metric applies to canisters that ran out of cycles. In particular,
+   * uninstalling code explicitly would not result in this metric being updated.
+   * In fact, others might be updated in that case, e.g. cycles for ingress induction
+   * if the uninstallation of the canister was requested via an ingress message.
+   */
+  uninstall: bigint;
+  ingress_induction: bigint;
+  request_and_response_transmission: bigint;
+  compute_allocation: bigint;
+}
 export interface definite_canister_settings {
   freezing_threshold: bigint;
   wasm_memory_threshold: bigint;
@@ -277,6 +304,9 @@ export interface list_canister_snapshots_args {
   canister_id: canister_id;
 }
 export type list_canister_snapshots_result = Array<snapshot>;
+export interface list_canisters_result {
+  canisters: Array<canister_id_range>;
+}
 export interface load_canister_snapshot_args {
   canister_id: canister_id;
   sender_canister_version: [] | [bigint];
@@ -528,6 +558,13 @@ export interface _SERVICE {
     [canister_metadata_args],
     canister_metadata_result
   >;
+  /**
+   * Returns canister related metrics
+   */
+  canister_metrics: ActorMethod<
+    [canister_metrics_args],
+    canister_metrics_result
+  >;
   canister_status: ActorMethod<[canister_status_args], canister_status_result>;
   clear_chunk_store: ActorMethod<[clear_chunk_store_args], undefined>;
   create_canister: ActorMethod<[create_canister_args], create_canister_result>;
@@ -558,6 +595,10 @@ export interface _SERVICE {
     [list_canister_snapshots_args],
     list_canister_snapshots_result
   >;
+  /**
+   * subnet admin methods
+   */
+  list_canisters: ActorMethod<[], list_canisters_result>;
   load_canister_snapshot: ActorMethod<[load_canister_snapshot_args], undefined>;
   /**
    * metrics interface

--- a/packages/canisters/src/declarations/ic-management/ic-management.did
+++ b/packages/canisters/src/declarations/ic-management/ic-management.did
@@ -1,4 +1,4 @@
-// Generated from dfinity/portal commit b8e9eff00e648fed39582848b650d952fe0674d1 for file 'docs/references/_attachments/ic.did'
+// Generated from dfinity/portal commit fe646b2990d25d0f00714d50d9df283dac5d2e91 for file 'docs/references/_attachments/ic.did'
 
 type canister_id = principal;
 type wasm_module = blob;
@@ -513,6 +513,15 @@ type fetch_canister_logs_result = record {
     canister_log_records : vec canister_log_record;
 };
 
+type canister_id_range = record {
+    start : canister_id;
+    end : canister_id;
+};
+
+type list_canisters_result = record {
+    canisters : vec canister_id_range;
+};
+
 type read_canister_snapshot_metadata_args = record {
     canister_id : canister_id;
     snapshot_id : snapshot_id;
@@ -623,6 +632,30 @@ type upload_canister_snapshot_data_args = record {
     chunk : blob;
 };
 
+type cycles_consumed = record {
+  memory : nat;
+  compute_allocation : nat;
+  ingress_induction : nat;
+  instructions : nat;
+  request_and_response_transmission : nat;
+  // This metric applies to canisters that ran out of cycles. In particular,
+  // uninstalling code explicitly would not result in this metric being updated.
+  // In fact, others might be updated in that case, e.g. cycles for ingress induction
+  // if the uninstallation of the canister was requested via an ingress message.
+  uninstall : nat;
+  canister_creation : nat;
+  http_outcalls : nat;
+  burned_cycles : nat;
+};
+
+type canister_metrics_args = record {
+  canister_id : canister_id;
+};
+
+type canister_metrics_result = record {
+  cycles_consumed : cycles_consumed;
+};
+
 service ic : {
     create_canister : (create_canister_args) -> (create_canister_result);
     update_settings : (update_settings_args) -> ();
@@ -635,6 +668,8 @@ service ic : {
     start_canister : (start_canister_args) -> ();
     stop_canister : (stop_canister_args) -> ();
     canister_status : (canister_status_args) -> (canister_status_result) query;
+    // Returns canister related metrics
+    canister_metrics: (canister_metrics_args) -> (canister_metrics_result) query;
     delete_canister : (delete_canister_args) -> ();
     deposit_cycles : (deposit_cycles_args) -> ();
     raw_rand : () -> (raw_rand_result);
@@ -685,4 +720,7 @@ service ic : {
 
     // canister logging
     fetch_canister_logs : (fetch_canister_logs_args) -> (fetch_canister_logs_result) query;
+
+    // subnet admin methods
+    list_canisters : () -> (list_canisters_result) query;
 };

--- a/packages/canisters/src/declarations/ic-management/ic-management.idl.js
+++ b/packages/canisters/src/declarations/ic-management/ic-management.idl.js
@@ -135,6 +135,21 @@ export const idlFactory = ({ IDL }) => {
     canister_id: canister_id,
   });
   const canister_metadata_result = IDL.Record({ value: IDL.Vec(IDL.Nat8) });
+  const canister_metrics_args = IDL.Record({ canister_id: canister_id });
+  const cycles_consumed = IDL.Record({
+    memory: IDL.Nat,
+    canister_creation: IDL.Nat,
+    burned_cycles: IDL.Nat,
+    http_outcalls: IDL.Nat,
+    instructions: IDL.Nat,
+    uninstall: IDL.Nat,
+    ingress_induction: IDL.Nat,
+    request_and_response_transmission: IDL.Nat,
+    compute_allocation: IDL.Nat,
+  });
+  const canister_metrics_result = IDL.Record({
+    cycles_consumed: cycles_consumed,
+  });
   const canister_status_args = IDL.Record({ canister_id: canister_id });
   const environment_variable = IDL.Record({
     value: IDL.Text,
@@ -310,6 +325,13 @@ export const idlFactory = ({ IDL }) => {
     taken_at_timestamp: IDL.Nat64,
   });
   const list_canister_snapshots_result = IDL.Vec(snapshot);
+  const canister_id_range = IDL.Record({
+    end: canister_id,
+    start: canister_id,
+  });
+  const list_canisters_result = IDL.Record({
+    canisters: IDL.Vec(canister_id_range),
+  });
   const load_canister_snapshot_args = IDL.Record({
     canister_id: canister_id,
     sender_canister_version: IDL.Opt(IDL.Nat64),
@@ -553,6 +575,11 @@ export const idlFactory = ({ IDL }) => {
       [canister_metadata_result],
       [],
     ),
+    canister_metrics: IDL.Func(
+      [canister_metrics_args],
+      [canister_metrics_result],
+      ["query"],
+    ),
     canister_status: IDL.Func(
       [canister_status_args],
       [canister_status_result],
@@ -585,6 +612,7 @@ export const idlFactory = ({ IDL }) => {
       [list_canister_snapshots_result],
       [],
     ),
+    list_canisters: IDL.Func([], [list_canisters_result], ["query"]),
     load_canister_snapshot: IDL.Func([load_canister_snapshot_args], [], []),
     node_metrics_history: IDL.Func(
       [node_metrics_history_args],

--- a/packages/canisters/src/declarations/ledger-icp/index.did
+++ b/packages/canisters/src/declarations/ledger-icp/index.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 606cab7 (2026-04-01 tags: release-2026-04-02_04-48-base) 'rs/ledger_suite/icp/index/index.did' by import-candid
+// Generated from IC repo commit 93274f1 (2026-06-15 tags: release-2026-06-12_04-52-hotfix) 'rs/ledger_suite/icp/index/index.did' by import-candid
 
 type Account = record { owner : principal; subaccount : opt vec nat8 };
 type GetAccountIdentifierTransactionsArgs = record {

--- a/packages/canisters/src/declarations/ledger-icp/ledger.did
+++ b/packages/canisters/src/declarations/ledger-icp/ledger.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 606cab7 (2026-04-01 tags: release-2026-04-02_04-48-base) 'rs/ledger_suite/icp/ledger.did' by import-candid
+// Generated from IC repo commit 93274f1 (2026-06-15 tags: release-2026-06-12_04-52-hotfix) 'rs/ledger_suite/icp/ledger.did' by import-candid
 
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 

--- a/packages/canisters/src/declarations/ledger-icrc/icrc_index.certified.idl.js
+++ b/packages/canisters/src/declarations/ledger-icrc/icrc_index.certified.idl.js
@@ -58,6 +58,22 @@ export const idlFactory = ({ IDL }) => {
     expires_at: IDL.Opt(IDL.Nat64),
     spender: Account,
   });
+  const AuthorizedBurn = IDL.Record({
+    from: Account,
+    mthd: IDL.Opt(IDL.Text),
+    caller: IDL.Opt(IDL.Principal),
+    created_at_time: IDL.Opt(IDL.Nat64),
+    amount: IDL.Nat,
+    reason: IDL.Opt(IDL.Text),
+  });
+  const AuthorizedMint = IDL.Record({
+    to: Account,
+    mthd: IDL.Opt(IDL.Text),
+    caller: IDL.Opt(IDL.Principal),
+    created_at_time: IDL.Opt(IDL.Nat64),
+    amount: IDL.Nat,
+    reason: IDL.Opt(IDL.Text),
+  });
   const FeeCollector = IDL.Record({
     ts: IDL.Opt(IDL.Nat64),
     mthd: IDL.Opt(IDL.Text),
@@ -78,6 +94,8 @@ export const idlFactory = ({ IDL }) => {
     kind: IDL.Text,
     mint: IDL.Opt(Mint),
     approve: IDL.Opt(Approve),
+    authorized_burn: IDL.Opt(AuthorizedBurn),
+    authorized_mint: IDL.Opt(AuthorizedMint),
     fee_collector: IDL.Opt(FeeCollector),
     timestamp: IDL.Nat64,
     transfer: IDL.Opt(Transfer),

--- a/packages/canisters/src/declarations/ledger-icrc/icrc_index.d.ts
+++ b/packages/canisters/src/declarations/ledger-icrc/icrc_index.d.ts
@@ -24,6 +24,22 @@ export interface Approve {
   expires_at: [] | [bigint];
   spender: Account;
 }
+export interface AuthorizedBurn {
+  from: Account;
+  mthd: [] | [string];
+  caller: [] | [Principal];
+  created_at_time: [] | [bigint];
+  amount: bigint;
+  reason: [] | [string];
+}
+export interface AuthorizedMint {
+  to: Account;
+  mthd: [] | [string];
+  caller: [] | [Principal];
+  created_at_time: [] | [bigint];
+  amount: bigint;
+  reason: [] | [string];
+}
 export type Block = Value;
 export type BlockIndex = bigint;
 export interface Burn {
@@ -121,6 +137,8 @@ export interface Transaction {
   kind: string;
   mint: [] | [Mint];
   approve: [] | [Approve];
+  authorized_burn: [] | [AuthorizedBurn];
+  authorized_mint: [] | [AuthorizedMint];
   fee_collector: [] | [FeeCollector];
   timestamp: bigint;
   transfer: [] | [Transfer];

--- a/packages/canisters/src/declarations/ledger-icrc/icrc_index.did
+++ b/packages/canisters/src/declarations/ledger-icrc/icrc_index.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 606cab7 (2026-04-01 tags: release-2026-04-02_04-48-base) 'rs/ledger_suite/icrc1/index-ng/index-ng.did' by import-candid
+// Generated from IC repo commit 93274f1 (2026-06-15 tags: release-2026-06-12_04-52-hotfix) 'rs/ledger_suite/icrc1/index-ng/index-ng.did' by import-candid
 
 type Tokens = nat;
 
@@ -75,8 +75,28 @@ type Transaction = record {
   mint : opt Mint;
   approve : opt Approve;
   fee_collector : opt FeeCollector;
+  authorized_mint : opt AuthorizedMint;
+  authorized_burn : opt AuthorizedBurn;
   timestamp : nat64;
   transfer : opt Transfer
+};
+
+type AuthorizedMint = record {
+  to : Account;
+  amount : nat;
+  created_at_time : opt nat64;
+  caller : opt principal;
+  mthd : opt text;
+  reason : opt text
+};
+
+type AuthorizedBurn = record {
+  from : Account;
+  amount : nat;
+  created_at_time : opt nat64;
+  caller : opt principal;
+  mthd : opt text;
+  reason : opt text
 };
 
 type FeeCollector = record {

--- a/packages/canisters/src/declarations/ledger-icrc/icrc_index.idl.js
+++ b/packages/canisters/src/declarations/ledger-icrc/icrc_index.idl.js
@@ -58,6 +58,22 @@ export const idlFactory = ({ IDL }) => {
     expires_at: IDL.Opt(IDL.Nat64),
     spender: Account,
   });
+  const AuthorizedBurn = IDL.Record({
+    from: Account,
+    mthd: IDL.Opt(IDL.Text),
+    caller: IDL.Opt(IDL.Principal),
+    created_at_time: IDL.Opt(IDL.Nat64),
+    amount: IDL.Nat,
+    reason: IDL.Opt(IDL.Text),
+  });
+  const AuthorizedMint = IDL.Record({
+    to: Account,
+    mthd: IDL.Opt(IDL.Text),
+    caller: IDL.Opt(IDL.Principal),
+    created_at_time: IDL.Opt(IDL.Nat64),
+    amount: IDL.Nat,
+    reason: IDL.Opt(IDL.Text),
+  });
   const FeeCollector = IDL.Record({
     ts: IDL.Opt(IDL.Nat64),
     mthd: IDL.Opt(IDL.Text),
@@ -78,6 +94,8 @@ export const idlFactory = ({ IDL }) => {
     kind: IDL.Text,
     mint: IDL.Opt(Mint),
     approve: IDL.Opt(Approve),
+    authorized_burn: IDL.Opt(AuthorizedBurn),
+    authorized_mint: IDL.Opt(AuthorizedMint),
     fee_collector: IDL.Opt(FeeCollector),
     timestamp: IDL.Nat64,
     transfer: IDL.Opt(Transfer),

--- a/packages/canisters/src/declarations/ledger-icrc/icrc_ledger.certified.idl.js
+++ b/packages/canisters/src/declarations/ledger-icrc/icrc_ledger.certified.idl.js
@@ -35,7 +35,7 @@ export const idlFactory = ({ IDL }) => {
     SetTo: Account,
     Unset: IDL.Null,
   });
-  const FeatureFlags = IDL.Record({ icrc2: IDL.Bool });
+  const FeatureFlags = IDL.Record({ icrc152: IDL.Bool, icrc2: IDL.Bool });
   const UpgradeArgs = IDL.Record({
     change_archive_options: IDL.Opt(ChangeArchiveOptions),
     token_symbol: IDL.Opt(IDL.Text),
@@ -147,6 +147,22 @@ export const idlFactory = ({ IDL }) => {
     expires_at: IDL.Opt(Timestamp),
     spender: Account,
   });
+  const AuthorizedBurn = IDL.Record({
+    from: Account,
+    mthd: IDL.Opt(IDL.Text),
+    caller: IDL.Opt(IDL.Principal),
+    created_at_time: IDL.Opt(Timestamp),
+    amount: IDL.Nat,
+    reason: IDL.Opt(IDL.Text),
+  });
+  const AuthorizedMint = IDL.Record({
+    to: Account,
+    mthd: IDL.Opt(IDL.Text),
+    caller: IDL.Opt(IDL.Principal),
+    created_at_time: IDL.Opt(Timestamp),
+    amount: IDL.Nat,
+    reason: IDL.Opt(IDL.Text),
+  });
   const FeeCollector = IDL.Record({
     ts: IDL.Opt(IDL.Nat64),
     mthd: IDL.Opt(IDL.Text),
@@ -167,6 +183,8 @@ export const idlFactory = ({ IDL }) => {
     kind: IDL.Text,
     mint: IDL.Opt(Mint),
     approve: IDL.Opt(Approve),
+    authorized_burn: IDL.Opt(AuthorizedBurn),
+    authorized_mint: IDL.Opt(AuthorizedMint),
     fee_collector: IDL.Opt(FeeCollector),
     timestamp: Timestamp,
     transfer: IDL.Opt(Transfer),
@@ -223,6 +241,45 @@ export const idlFactory = ({ IDL }) => {
   const GetIndexPrincipalResult = IDL.Variant({
     Ok: IDL.Principal,
     Err: GetIndexPrincipalError,
+  });
+  const Icrc152BurnArgs = IDL.Record({
+    from: Account,
+    created_at_time: IDL.Nat64,
+    amount: IDL.Nat,
+    reason: IDL.Opt(IDL.Text),
+  });
+  const Icrc152BurnError = IDL.Variant({
+    InvalidAccount: IDL.Text,
+    GenericError: IDL.Record({
+      message: IDL.Text,
+      error_code: IDL.Nat,
+    }),
+    Duplicate: IDL.Record({ duplicate_of: IDL.Nat }),
+    InsufficientBalance: IDL.Record({ balance: IDL.Nat }),
+    Unauthorized: IDL.Text,
+  });
+  const Icrc152BurnResult = IDL.Variant({
+    Ok: IDL.Nat,
+    Err: Icrc152BurnError,
+  });
+  const Icrc152MintArgs = IDL.Record({
+    to: Account,
+    created_at_time: IDL.Nat64,
+    amount: IDL.Nat,
+    reason: IDL.Opt(IDL.Text),
+  });
+  const Icrc152MintError = IDL.Variant({
+    InvalidAccount: IDL.Text,
+    GenericError: IDL.Record({
+      message: IDL.Text,
+      error_code: IDL.Nat,
+    }),
+    Duplicate: IDL.Record({ duplicate_of: IDL.Nat }),
+    Unauthorized: IDL.Text,
+  });
+  const Icrc152MintResult = IDL.Variant({
+    Ok: IDL.Nat,
+    Err: Icrc152MintError,
   });
   const Tokens = IDL.Nat;
   const StandardRecord = IDL.Record({ url: IDL.Text, name: IDL.Text });
@@ -424,6 +481,8 @@ export const idlFactory = ({ IDL }) => {
       [IDL.Vec(IDL.Record({ url: IDL.Text, name: IDL.Text }))],
       [],
     ),
+    icrc152_burn: IDL.Func([Icrc152BurnArgs], [Icrc152BurnResult], []),
+    icrc152_mint: IDL.Func([Icrc152MintArgs], [Icrc152MintResult], []),
     icrc1_balance_of: IDL.Func([Account], [Tokens], []),
     icrc1_decimals: IDL.Func([], [IDL.Nat8], []),
     icrc1_fee: IDL.Func([], [Tokens], []),
@@ -488,7 +547,7 @@ export const init = ({ IDL }) => {
     SetTo: Account,
     Unset: IDL.Null,
   });
-  const FeatureFlags = IDL.Record({ icrc2: IDL.Bool });
+  const FeatureFlags = IDL.Record({ icrc152: IDL.Bool, icrc2: IDL.Bool });
   const UpgradeArgs = IDL.Record({
     change_archive_options: IDL.Opt(ChangeArchiveOptions),
     token_symbol: IDL.Opt(IDL.Text),

--- a/packages/canisters/src/declarations/ledger-icrc/icrc_ledger.d.ts
+++ b/packages/canisters/src/declarations/ledger-icrc/icrc_ledger.d.ts
@@ -66,6 +66,22 @@ export interface ArchiveInfo {
   canister_id: Principal;
   block_range_start: BlockIndex;
 }
+export interface AuthorizedBurn {
+  from: Account;
+  mthd: [] | [string];
+  caller: [] | [Principal];
+  created_at_time: [] | [Timestamp];
+  amount: bigint;
+  reason: [] | [string];
+}
+export interface AuthorizedMint {
+  to: Account;
+  mthd: [] | [string];
+  caller: [] | [Principal];
+  created_at_time: [] | [Timestamp];
+  amount: bigint;
+  reason: [] | [string];
+}
 export type Block = Value;
 export type BlockIndex = bigint;
 /**
@@ -122,6 +138,7 @@ export interface DataCertificate {
  */
 export type Duration = bigint;
 export interface FeatureFlags {
+  icrc152: boolean;
   icrc2: boolean;
 }
 export interface FeeCollector {
@@ -329,6 +346,31 @@ export type ICRC3Value =
   | { Blob: Uint8Array }
   | { Text: string }
   | { Array: Array<ICRC3Value> };
+export interface Icrc152BurnArgs {
+  from: Account;
+  created_at_time: bigint;
+  amount: bigint;
+  reason: [] | [string];
+}
+export type Icrc152BurnError =
+  | { InvalidAccount: string }
+  | { GenericError: { message: string; error_code: bigint } }
+  | { Duplicate: { duplicate_of: bigint } }
+  | { InsufficientBalance: { balance: bigint } }
+  | { Unauthorized: string };
+export type Icrc152BurnResult = { Ok: bigint } | { Err: Icrc152BurnError };
+export interface Icrc152MintArgs {
+  to: Account;
+  created_at_time: bigint;
+  amount: bigint;
+  reason: [] | [string];
+}
+export type Icrc152MintError =
+  | { InvalidAccount: string }
+  | { GenericError: { message: string; error_code: bigint } }
+  | { Duplicate: { duplicate_of: bigint } }
+  | { Unauthorized: string };
+export type Icrc152MintResult = { Ok: bigint } | { Err: Icrc152MintError };
 export type Icrc21Value =
   | { Text: { content: string } }
   | {
@@ -409,6 +451,8 @@ export interface Transaction {
   kind: string;
   mint: [] | [Mint];
   approve: [] | [Approve];
+  authorized_burn: [] | [AuthorizedBurn];
+  authorized_mint: [] | [AuthorizedMint];
   fee_collector: [] | [FeeCollector];
   timestamp: Timestamp;
   transfer: [] | [Transfer];
@@ -567,6 +611,8 @@ export interface _SERVICE {
     [],
     Array<{ url: string; name: string }>
   >;
+  icrc152_burn: ActorMethod<[Icrc152BurnArgs], Icrc152BurnResult>;
+  icrc152_mint: ActorMethod<[Icrc152MintArgs], Icrc152MintResult>;
   icrc1_balance_of: ActorMethod<[Account], Tokens>;
   icrc1_decimals: ActorMethod<[], number>;
   icrc1_fee: ActorMethod<[], Tokens>;

--- a/packages/canisters/src/declarations/ledger-icrc/icrc_ledger.did
+++ b/packages/canisters/src/declarations/ledger-icrc/icrc_ledger.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 606cab7 (2026-04-01 tags: release-2026-04-02_04-48-base) 'rs/ledger_suite/icrc1/ledger/ledger.did' by import-candid
+// Generated from IC repo commit 93274f1 (2026-06-15 tags: release-2026-06-12_04-52-hotfix) 'rs/ledger_suite/icrc1/ledger/ledger.did' by import-candid
 
 type BlockIndex = nat;
 type Subaccount = blob;
@@ -94,7 +94,8 @@ type MetadataValue = variant {
 };
 
 type FeatureFlags = record {
-  icrc2 : bool
+  icrc2 : bool;
+  icrc152 : bool
 };
 
 // The initialization parameters of the Ledger
@@ -227,8 +228,28 @@ type Transaction = record {
   mint : opt Mint;
   approve : opt Approve;
   fee_collector : opt FeeCollector;
+  authorized_mint : opt AuthorizedMint;
+  authorized_burn : opt AuthorizedBurn;
   timestamp : Timestamp;
   transfer : opt Transfer
+};
+
+type AuthorizedMint = record {
+  to : Account;
+  amount : nat;
+  created_at_time : opt Timestamp;
+  caller : opt principal;
+  mthd : opt text;
+  reason : opt text
+};
+
+type AuthorizedBurn = record {
+  from : Account;
+  amount : nat;
+  created_at_time : opt Timestamp;
+  caller : opt principal;
+  mthd : opt text;
+  reason : opt text
 };
 
 type FeeCollector = record {
@@ -550,6 +571,39 @@ type GetIndexPrincipalError = variant {
   }
 };
 
+type Icrc152MintArgs = record {
+  to : Account;
+  amount : nat;
+  created_at_time : nat64;
+  reason : opt text
+};
+
+type Icrc152MintError = variant {
+  Unauthorized : text;
+  InvalidAccount : text;
+  Duplicate : record { duplicate_of : nat };
+  GenericError : record { error_code : nat; message : text }
+};
+
+type Icrc152MintResult = variant { Ok : nat; Err : Icrc152MintError };
+
+type Icrc152BurnArgs = record {
+  from : Account;
+  amount : nat;
+  created_at_time : nat64;
+  reason : opt text
+};
+
+type Icrc152BurnError = variant {
+  Unauthorized : text;
+  InvalidAccount : text;
+  InsufficientBalance : record { balance : nat };
+  Duplicate : record { duplicate_of : nat };
+  GenericError : record { error_code : nat; message : text }
+};
+
+type Icrc152BurnResult = variant { Ok : nat; Err : Icrc152BurnError };
+
 service : (ledger_arg : LedgerArg) -> {
   archives : () -> (vec ArchiveInfo) query;
   get_transactions : (GetTransactionsRequest) -> (GetTransactionsResponse) query;
@@ -582,6 +636,9 @@ service : (ledger_arg : LedgerArg) -> {
   icrc103_get_allowances : (GetAllowancesArgs) -> (icrc103_get_allowances_response) query;
 
   icrc106_get_index_principal : () -> (GetIndexPrincipalResult) query;
+
+  icrc152_mint : (Icrc152MintArgs) -> (Icrc152MintResult);
+  icrc152_burn : (Icrc152BurnArgs) -> (Icrc152BurnResult);
 
   is_ledger_ready : () -> (bool) query
 }

--- a/packages/canisters/src/declarations/ledger-icrc/icrc_ledger.idl.js
+++ b/packages/canisters/src/declarations/ledger-icrc/icrc_ledger.idl.js
@@ -35,7 +35,7 @@ export const idlFactory = ({ IDL }) => {
     SetTo: Account,
     Unset: IDL.Null,
   });
-  const FeatureFlags = IDL.Record({ icrc2: IDL.Bool });
+  const FeatureFlags = IDL.Record({ icrc152: IDL.Bool, icrc2: IDL.Bool });
   const UpgradeArgs = IDL.Record({
     change_archive_options: IDL.Opt(ChangeArchiveOptions),
     token_symbol: IDL.Opt(IDL.Text),
@@ -151,6 +151,22 @@ export const idlFactory = ({ IDL }) => {
     expires_at: IDL.Opt(Timestamp),
     spender: Account,
   });
+  const AuthorizedBurn = IDL.Record({
+    from: Account,
+    mthd: IDL.Opt(IDL.Text),
+    caller: IDL.Opt(IDL.Principal),
+    created_at_time: IDL.Opt(Timestamp),
+    amount: IDL.Nat,
+    reason: IDL.Opt(IDL.Text),
+  });
+  const AuthorizedMint = IDL.Record({
+    to: Account,
+    mthd: IDL.Opt(IDL.Text),
+    caller: IDL.Opt(IDL.Principal),
+    created_at_time: IDL.Opt(Timestamp),
+    amount: IDL.Nat,
+    reason: IDL.Opt(IDL.Text),
+  });
   const FeeCollector = IDL.Record({
     ts: IDL.Opt(IDL.Nat64),
     mthd: IDL.Opt(IDL.Text),
@@ -171,6 +187,8 @@ export const idlFactory = ({ IDL }) => {
     kind: IDL.Text,
     mint: IDL.Opt(Mint),
     approve: IDL.Opt(Approve),
+    authorized_burn: IDL.Opt(AuthorizedBurn),
+    authorized_mint: IDL.Opt(AuthorizedMint),
     fee_collector: IDL.Opt(FeeCollector),
     timestamp: Timestamp,
     transfer: IDL.Opt(Transfer),
@@ -227,6 +245,45 @@ export const idlFactory = ({ IDL }) => {
   const GetIndexPrincipalResult = IDL.Variant({
     Ok: IDL.Principal,
     Err: GetIndexPrincipalError,
+  });
+  const Icrc152BurnArgs = IDL.Record({
+    from: Account,
+    created_at_time: IDL.Nat64,
+    amount: IDL.Nat,
+    reason: IDL.Opt(IDL.Text),
+  });
+  const Icrc152BurnError = IDL.Variant({
+    InvalidAccount: IDL.Text,
+    GenericError: IDL.Record({
+      message: IDL.Text,
+      error_code: IDL.Nat,
+    }),
+    Duplicate: IDL.Record({ duplicate_of: IDL.Nat }),
+    InsufficientBalance: IDL.Record({ balance: IDL.Nat }),
+    Unauthorized: IDL.Text,
+  });
+  const Icrc152BurnResult = IDL.Variant({
+    Ok: IDL.Nat,
+    Err: Icrc152BurnError,
+  });
+  const Icrc152MintArgs = IDL.Record({
+    to: Account,
+    created_at_time: IDL.Nat64,
+    amount: IDL.Nat,
+    reason: IDL.Opt(IDL.Text),
+  });
+  const Icrc152MintError = IDL.Variant({
+    InvalidAccount: IDL.Text,
+    GenericError: IDL.Record({
+      message: IDL.Text,
+      error_code: IDL.Nat,
+    }),
+    Duplicate: IDL.Record({ duplicate_of: IDL.Nat }),
+    Unauthorized: IDL.Text,
+  });
+  const Icrc152MintResult = IDL.Variant({
+    Ok: IDL.Nat,
+    Err: Icrc152MintError,
   });
   const Tokens = IDL.Nat;
   const StandardRecord = IDL.Record({ url: IDL.Text, name: IDL.Text });
@@ -432,6 +489,8 @@ export const idlFactory = ({ IDL }) => {
       [IDL.Vec(IDL.Record({ url: IDL.Text, name: IDL.Text }))],
       ["query"],
     ),
+    icrc152_burn: IDL.Func([Icrc152BurnArgs], [Icrc152BurnResult], []),
+    icrc152_mint: IDL.Func([Icrc152MintArgs], [Icrc152MintResult], []),
     icrc1_balance_of: IDL.Func([Account], [Tokens], ["query"]),
     icrc1_decimals: IDL.Func([], [IDL.Nat8], ["query"]),
     icrc1_fee: IDL.Func([], [Tokens], ["query"]),
@@ -508,7 +567,7 @@ export const init = ({ IDL }) => {
     SetTo: Account,
     Unset: IDL.Null,
   });
-  const FeatureFlags = IDL.Record({ icrc2: IDL.Bool });
+  const FeatureFlags = IDL.Record({ icrc152: IDL.Bool, icrc2: IDL.Bool });
   const UpgradeArgs = IDL.Record({
     change_archive_options: IDL.Opt(ChangeArchiveOptions),
     token_symbol: IDL.Opt(IDL.Text),

--- a/packages/canisters/src/declarations/nns/genesis_token.did
+++ b/packages/canisters/src/declarations/nns/genesis_token.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit b4b0230 (2026-04-09 tags: release-2026-04-10_04-17-base) 'rs/nns/gtc/canister/gtc.did' by import-candid
+// Generated from IC repo commit 93274f1 (2026-06-15 tags: release-2026-06-12_04-52-hotfix) 'rs/nns/gtc/canister/gtc.did' by import-candid
 
 type AccountState = record {
   authenticated_principal_id : opt principal;

--- a/packages/canisters/src/declarations/nns/governance.certified.idl.js
+++ b/packages/canisters/src/declarations/nns/governance.certified.idl.js
@@ -197,6 +197,16 @@ export const idlFactory = ({ IDL }) => {
     error_type: IDL.Int32,
   });
   const Ballot = IDL.Record({ vote: IDL.Int32, voting_power: IDL.Nat64 });
+  const TakeCanisterSnapshotOk = IDL.Record({
+    snapshot_id: IDL.Vec(IDL.Nat8),
+  });
+  const CreateCanisterAndInstallCodeOk = IDL.Record({
+    canister_id: IDL.Opt(IDL.Principal),
+  });
+  const SuccessfulProposalExecutionValue = IDL.Variant({
+    TakeCanisterSnapshot: TakeCanisterSnapshotOk,
+    CreateCanisterAndInstallCode: CreateCanisterAndInstallCodeOk,
+  });
   const SwapParticipationLimits = IDL.Record({
     min_participant_icp_e8s: IDL.Opt(IDL.Nat64),
     max_participant_icp_e8s: IDL.Opt(IDL.Nat64),
@@ -297,6 +307,7 @@ export const idlFactory = ({ IDL }) => {
     known_neuron_data: IDL.Opt(KnownNeuronData),
   });
   const FulfillSubnetRentalRequest = IDL.Record({
+    initial_dkg_subnet_id: IDL.Opt(IDL.Principal),
     user: IDL.Opt(IDL.Principal),
     replica_version_id: IDL.Opt(IDL.Text),
     node_ids: IDL.Opt(IDL.Vec(IDL.Principal)),
@@ -421,6 +432,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const GuestLaunchMeasurementMetadata = IDL.Record({
     kernel_cmdline: IDL.Opt(IDL.Text),
+    vcpu_type: IDL.Opt(IDL.Text),
   });
   const GuestLaunchMeasurement = IDL.Record({
     metadata: IDL.Opt(GuestLaunchMeasurementMetadata),
@@ -670,6 +682,7 @@ export const idlFactory = ({ IDL }) => {
     proposal_timestamp_seconds: IDL.Nat64,
     reward_event_round: IDL.Nat64,
     failed_timestamp_seconds: IDL.Nat64,
+    success_value: IDL.Opt(SuccessfulProposalExecutionValue),
     neurons_fund_data: IDL.Opt(NeuronsFundData),
     reject_cost_e8s: IDL.Nat64,
     derived_proposal_information: IDL.Opt(DerivedProposalInformation),
@@ -788,6 +801,14 @@ export const idlFactory = ({ IDL }) => {
     Err: GovernanceError,
   });
   const Result_2 = IDL.Variant({ Ok: Neuron, Err: GovernanceError });
+  const GetMaturityModulationRequest = IDL.Record({});
+  const MaturityModulation = IDL.Record({
+    current_value_permyriad: IDL.Opt(IDL.Int32),
+    updated_at_timestamp_seconds: IDL.Opt(IDL.Nat64),
+  });
+  const GetMaturityModulationResponse = IDL.Record({
+    maturity_modulation: IDL.Opt(MaturityModulation),
+  });
   const Result_3 = IDL.Variant({
     Ok: GovernanceCachedMetrics,
     Err: GovernanceError,
@@ -802,6 +823,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const NeuronInfo = IDL.Record({
     id: IDL.Opt(NeuronId),
+    staked_maturity_e8s_equivalent: IDL.Opt(IDL.Nat64),
     dissolve_delay_seconds: IDL.Nat64,
     recent_ballots: IDL.Vec(BallotInfo),
     voting_power_refreshed_timestamp_seconds: IDL.Opt(IDL.Nat64),
@@ -857,6 +879,7 @@ export const idlFactory = ({ IDL }) => {
     reward_event_round: IDL.Nat64,
     deadline_timestamp_seconds: IDL.Opt(IDL.Nat64),
     failed_timestamp_seconds: IDL.Nat64,
+    success_value: IDL.Opt(SuccessfulProposalExecutionValue),
     reject_cost_e8s: IDL.Nat64,
     derived_proposal_information: IDL.Opt(DerivedProposalInformation),
     latest_tally: IDL.Opt(Tally),
@@ -1108,6 +1131,11 @@ export const idlFactory = ({ IDL }) => {
       [],
     ),
     get_latest_reward_event: IDL.Func([], [RewardEvent], []),
+    get_maturity_modulation: IDL.Func(
+      [GetMaturityModulationRequest],
+      [GetMaturityModulationResponse],
+      [],
+    ),
     get_metrics: IDL.Func([], [Result_3], []),
     get_monthly_node_provider_rewards: IDL.Func([], [Result_4], []),
     get_most_recent_monthly_node_provider_rewards: IDL.Func(
@@ -1370,6 +1398,16 @@ export const init = ({ IDL }) => {
     error_type: IDL.Int32,
   });
   const Ballot = IDL.Record({ vote: IDL.Int32, voting_power: IDL.Nat64 });
+  const TakeCanisterSnapshotOk = IDL.Record({
+    snapshot_id: IDL.Vec(IDL.Nat8),
+  });
+  const CreateCanisterAndInstallCodeOk = IDL.Record({
+    canister_id: IDL.Opt(IDL.Principal),
+  });
+  const SuccessfulProposalExecutionValue = IDL.Variant({
+    TakeCanisterSnapshot: TakeCanisterSnapshotOk,
+    CreateCanisterAndInstallCode: CreateCanisterAndInstallCodeOk,
+  });
   const SwapParticipationLimits = IDL.Record({
     min_participant_icp_e8s: IDL.Opt(IDL.Nat64),
     max_participant_icp_e8s: IDL.Opt(IDL.Nat64),
@@ -1470,6 +1508,7 @@ export const init = ({ IDL }) => {
     known_neuron_data: IDL.Opt(KnownNeuronData),
   });
   const FulfillSubnetRentalRequest = IDL.Record({
+    initial_dkg_subnet_id: IDL.Opt(IDL.Principal),
     user: IDL.Opt(IDL.Principal),
     replica_version_id: IDL.Opt(IDL.Text),
     node_ids: IDL.Opt(IDL.Vec(IDL.Principal)),
@@ -1594,6 +1633,7 @@ export const init = ({ IDL }) => {
   });
   const GuestLaunchMeasurementMetadata = IDL.Record({
     kernel_cmdline: IDL.Opt(IDL.Text),
+    vcpu_type: IDL.Opt(IDL.Text),
   });
   const GuestLaunchMeasurement = IDL.Record({
     metadata: IDL.Opt(GuestLaunchMeasurementMetadata),
@@ -1843,6 +1883,7 @@ export const init = ({ IDL }) => {
     proposal_timestamp_seconds: IDL.Nat64,
     reward_event_round: IDL.Nat64,
     failed_timestamp_seconds: IDL.Nat64,
+    success_value: IDL.Opt(SuccessfulProposalExecutionValue),
     neurons_fund_data: IDL.Opt(NeuronsFundData),
     reject_cost_e8s: IDL.Nat64,
     derived_proposal_information: IDL.Opt(DerivedProposalInformation),

--- a/packages/canisters/src/declarations/nns/governance.d.ts
+++ b/packages/canisters/src/declarations/nns/governance.d.ts
@@ -182,6 +182,9 @@ export interface CreateCanisterAndInstallCode {
   install_arg_hash: [] | [Uint8Array];
   host_subnet_id: [] | [Principal];
 }
+export interface CreateCanisterAndInstallCodeOk {
+  canister_id: [] | [Principal];
+}
 export interface CreateCanisterAndInstallCodeRequest {
   wasm_module: [] | [WasmModule];
   canister_settings: [] | [CanisterSettings];
@@ -313,6 +316,11 @@ export interface FolloweesForTopic {
  */
 export interface FulfillSubnetRentalRequest {
   /**
+   * Optional subnet that should handle `setup_initial_dkg` for subnet creation.
+   * If not set, handling defaults to the NNS subnet.
+   */
+  initial_dkg_subnet_id: [] | [Principal];
+  /**
    * Identifies which rental request to fulfill.
    *
    * (Identifying the rental request by user works, because a user can have at
@@ -343,6 +351,10 @@ export interface FulfillSubnetRentalRequest {
    * Which nodes will be members of the subnet.
    */
   node_ids: [] | [Array<Principal>];
+}
+export type GetMaturityModulationRequest = {};
+export interface GetMaturityModulationResponse {
+  maturity_modulation: [] | [MaturityModulation];
 }
 export interface GetNeuronIndexRequest {
   page_size: [] | [number];
@@ -474,6 +486,10 @@ export interface GuestLaunchMeasurementMetadata {
    * Kernel command line used for this measurement.
    */
   kernel_cmdline: [] | [string];
+  /**
+   * Virtual CPU type used for this measurement.
+   */
+  vcpu_type: [] | [string];
 }
 export interface GuestLaunchMeasurements {
   guest_launch_measurements: [] | [Array<GuestLaunchMeasurement>];
@@ -732,6 +748,10 @@ export interface MaturityDisbursement {
   account_to_disburse_to: [] | [Account];
   finalize_disbursement_timestamp_seconds: [] | [bigint];
 }
+export interface MaturityModulation {
+  current_value_permyriad: [] | [number];
+  updated_at_timestamp_seconds: [] | [bigint];
+}
 export interface Merge {
   source_neuron_id: [] | [NeuronId];
 }
@@ -912,6 +932,10 @@ export interface NeuronIndexData {
  */
 export interface NeuronInfo {
   id: [] | [NeuronId];
+  /**
+   * See analogous field in Neuron.
+   */
+  staked_maturity_e8s_equivalent: [] | [bigint];
   dissolve_delay_seconds: bigint;
   recent_ballots: Array<BallotInfo>;
   voting_power_refreshed_timestamp_seconds: [] | [bigint];
@@ -1118,6 +1142,7 @@ export interface ProposalData {
   proposal_timestamp_seconds: bigint;
   reward_event_round: bigint;
   failed_timestamp_seconds: bigint;
+  success_value: [] | [SuccessfulProposalExecutionValue];
   neurons_fund_data: [] | [NeuronsFundData];
   reject_cost_e8s: bigint;
   derived_proposal_information: [] | [DerivedProposalInformation];
@@ -1144,6 +1169,7 @@ export interface ProposalInfo {
   reward_event_round: bigint;
   deadline_timestamp_seconds: [] | [bigint];
   failed_timestamp_seconds: bigint;
+  success_value: [] | [SuccessfulProposalExecutionValue];
   reject_cost_e8s: bigint;
   derived_proposal_information: [] | [DerivedProposalInformation];
   latest_tally: [] | [Tally];
@@ -1288,6 +1314,11 @@ export interface StopOrStartCanister {
   action: [] | [number];
   canister_id: [] | [Principal];
 }
+export type SuccessfulProposalExecutionValue =
+  | {
+      TakeCanisterSnapshot: TakeCanisterSnapshotOk;
+    }
+  | { CreateCanisterAndInstallCode: CreateCanisterAndInstallCodeOk };
 export interface SwapBackgroundInformation {
   ledger_index_canister_summary: [] | [CanisterSummary];
   fallback_controller_principal_ids: Array<Principal>;
@@ -1328,6 +1359,9 @@ export interface SwapParticipationLimits {
 export interface TakeCanisterSnapshot {
   replace_snapshot: [] | [Uint8Array];
   canister_id: [] | [Principal];
+}
+export interface TakeCanisterSnapshotOk {
+  snapshot_id: Uint8Array;
 }
 export interface Tally {
   no: bigint;
@@ -1447,6 +1481,10 @@ export interface _SERVICE {
     Result_2
   >;
   get_latest_reward_event: ActorMethod<[], RewardEvent>;
+  get_maturity_modulation: ActorMethod<
+    [GetMaturityModulationRequest],
+    GetMaturityModulationResponse
+  >;
   get_metrics: ActorMethod<[], Result_3>;
   get_monthly_node_provider_rewards: ActorMethod<[], Result_4>;
   get_most_recent_monthly_node_provider_rewards: ActorMethod<

--- a/packages/canisters/src/declarations/nns/governance.did
+++ b/packages/canisters/src/declarations/nns/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit b4b0230 (2026-04-09 tags: release-2026-04-10_04-17-base) 'rs/nns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 93274f1 (2026-06-15 tags: release-2026-06-12_04-52-hotfix) 'rs/nns/governance/canister/governance.did' by import-candid
 
 type AccountIdentifier = record {
   hash : blob;
@@ -249,6 +249,19 @@ type CreateCanisterAndInstallCodeRequest = record {
   install_arg : opt blob;
 };
 
+type CreateCanisterAndInstallCodeOk = record {
+  canister_id : opt principal;
+};
+
+type TakeCanisterSnapshotOk = record {
+  snapshot_id : blob;
+};
+
+type SuccessfulProposalExecutionValue = variant {
+  CreateCanisterAndInstallCode : CreateCanisterAndInstallCodeOk;
+  TakeCanisterSnapshot : TakeCanisterSnapshotOk;
+};
+
 type CreateServiceNervousSystem = record {
   url : opt text;
   governance_parameters : opt GovernanceParameters;
@@ -321,6 +334,17 @@ type Followees = record {
 
 type GetNeuronsFundAuditInfoRequest = record {
   nns_proposal_id : opt ProposalId;
+};
+
+type MaturityModulation = record {
+  current_value_permyriad : opt int32;
+  updated_at_timestamp_seconds : opt nat64;
+};
+
+type GetMaturityModulationRequest = record {};
+
+type GetMaturityModulationResponse = record {
+  maturity_modulation : opt MaturityModulation;
 };
 
 type GetNeuronsFundAuditInfoResponse = record {
@@ -904,6 +928,8 @@ type NeuronInfo = record {
   potential_voting_power : opt nat64;
   // See analogous field in Neuron.
   eight_year_gang_bonus_base_e8s : opt nat64;
+  // See analogous field in Neuron.
+  staked_maturity_e8s_equivalent : opt nat64;
 };
 
 type NeuronStakeTransfer = record {
@@ -1109,6 +1135,10 @@ type FulfillSubnetRentalRequest = record {
   //
   //     https://github.com/dfinity/ic/releases/latest
   replica_version_id : opt text;
+
+  // Optional subnet that should handle `setup_initial_dkg` for subnet creation.
+  // If not set, handling defaults to the NNS subnet.
+  initial_dkg_subnet_id : opt principal;
 };
 
 // Declares an approved set of alternative replica virtual machine software for
@@ -1143,6 +1173,8 @@ type GuestLaunchMeasurement = record {
 type GuestLaunchMeasurementMetadata = record {
   // Kernel command line used for this measurement.
   kernel_cmdline : opt text;
+  // Virtual CPU type used for this measurement.
+  vcpu_type : opt text;
 };
 
 type TakeCanisterSnapshot = record {
@@ -1170,6 +1202,7 @@ type ProposalData = record {
   original_total_community_fund_maturity_e8s_equivalent : opt nat64;
   total_potential_voting_power : opt nat64;
   topic: opt int32;
+  success_value : opt SuccessfulProposalExecutionValue;
 };
 
 type ProposalInfo = record {
@@ -1191,6 +1224,7 @@ type ProposalInfo = record {
   proposer : opt NeuronId;
   executed_timestamp_seconds : nat64;
   total_potential_voting_power : opt nat64;
+  success_value : opt SuccessfulProposalExecutionValue;
 };
 
 type RegisterVote = record {
@@ -1585,6 +1619,9 @@ service : (Governance) -> {
       Result_2,
     ) query;
   get_latest_reward_event : () -> (RewardEvent) query;
+  get_maturity_modulation : (GetMaturityModulationRequest) -> (
+      GetMaturityModulationResponse,
+    ) query;
   get_metrics : () -> (Result_3) query;
   get_monthly_node_provider_rewards : () -> (Result_4);
   get_most_recent_monthly_node_provider_rewards : () -> (

--- a/packages/canisters/src/declarations/nns/governance.idl.js
+++ b/packages/canisters/src/declarations/nns/governance.idl.js
@@ -197,6 +197,16 @@ export const idlFactory = ({ IDL }) => {
     error_type: IDL.Int32,
   });
   const Ballot = IDL.Record({ vote: IDL.Int32, voting_power: IDL.Nat64 });
+  const TakeCanisterSnapshotOk = IDL.Record({
+    snapshot_id: IDL.Vec(IDL.Nat8),
+  });
+  const CreateCanisterAndInstallCodeOk = IDL.Record({
+    canister_id: IDL.Opt(IDL.Principal),
+  });
+  const SuccessfulProposalExecutionValue = IDL.Variant({
+    TakeCanisterSnapshot: TakeCanisterSnapshotOk,
+    CreateCanisterAndInstallCode: CreateCanisterAndInstallCodeOk,
+  });
   const SwapParticipationLimits = IDL.Record({
     min_participant_icp_e8s: IDL.Opt(IDL.Nat64),
     max_participant_icp_e8s: IDL.Opt(IDL.Nat64),
@@ -297,6 +307,7 @@ export const idlFactory = ({ IDL }) => {
     known_neuron_data: IDL.Opt(KnownNeuronData),
   });
   const FulfillSubnetRentalRequest = IDL.Record({
+    initial_dkg_subnet_id: IDL.Opt(IDL.Principal),
     user: IDL.Opt(IDL.Principal),
     replica_version_id: IDL.Opt(IDL.Text),
     node_ids: IDL.Opt(IDL.Vec(IDL.Principal)),
@@ -421,6 +432,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const GuestLaunchMeasurementMetadata = IDL.Record({
     kernel_cmdline: IDL.Opt(IDL.Text),
+    vcpu_type: IDL.Opt(IDL.Text),
   });
   const GuestLaunchMeasurement = IDL.Record({
     metadata: IDL.Opt(GuestLaunchMeasurementMetadata),
@@ -670,6 +682,7 @@ export const idlFactory = ({ IDL }) => {
     proposal_timestamp_seconds: IDL.Nat64,
     reward_event_round: IDL.Nat64,
     failed_timestamp_seconds: IDL.Nat64,
+    success_value: IDL.Opt(SuccessfulProposalExecutionValue),
     neurons_fund_data: IDL.Opt(NeuronsFundData),
     reject_cost_e8s: IDL.Nat64,
     derived_proposal_information: IDL.Opt(DerivedProposalInformation),
@@ -788,6 +801,14 @@ export const idlFactory = ({ IDL }) => {
     Err: GovernanceError,
   });
   const Result_2 = IDL.Variant({ Ok: Neuron, Err: GovernanceError });
+  const GetMaturityModulationRequest = IDL.Record({});
+  const MaturityModulation = IDL.Record({
+    current_value_permyriad: IDL.Opt(IDL.Int32),
+    updated_at_timestamp_seconds: IDL.Opt(IDL.Nat64),
+  });
+  const GetMaturityModulationResponse = IDL.Record({
+    maturity_modulation: IDL.Opt(MaturityModulation),
+  });
   const Result_3 = IDL.Variant({
     Ok: GovernanceCachedMetrics,
     Err: GovernanceError,
@@ -802,6 +823,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const NeuronInfo = IDL.Record({
     id: IDL.Opt(NeuronId),
+    staked_maturity_e8s_equivalent: IDL.Opt(IDL.Nat64),
     dissolve_delay_seconds: IDL.Nat64,
     recent_ballots: IDL.Vec(BallotInfo),
     voting_power_refreshed_timestamp_seconds: IDL.Opt(IDL.Nat64),
@@ -857,6 +879,7 @@ export const idlFactory = ({ IDL }) => {
     reward_event_round: IDL.Nat64,
     deadline_timestamp_seconds: IDL.Opt(IDL.Nat64),
     failed_timestamp_seconds: IDL.Nat64,
+    success_value: IDL.Opt(SuccessfulProposalExecutionValue),
     reject_cost_e8s: IDL.Nat64,
     derived_proposal_information: IDL.Opt(DerivedProposalInformation),
     latest_tally: IDL.Opt(Tally),
@@ -1108,6 +1131,11 @@ export const idlFactory = ({ IDL }) => {
       ["query"],
     ),
     get_latest_reward_event: IDL.Func([], [RewardEvent], ["query"]),
+    get_maturity_modulation: IDL.Func(
+      [GetMaturityModulationRequest],
+      [GetMaturityModulationResponse],
+      ["query"],
+    ),
     get_metrics: IDL.Func([], [Result_3], ["query"]),
     get_monthly_node_provider_rewards: IDL.Func([], [Result_4], []),
     get_most_recent_monthly_node_provider_rewards: IDL.Func(
@@ -1378,6 +1406,16 @@ export const init = ({ IDL }) => {
     error_type: IDL.Int32,
   });
   const Ballot = IDL.Record({ vote: IDL.Int32, voting_power: IDL.Nat64 });
+  const TakeCanisterSnapshotOk = IDL.Record({
+    snapshot_id: IDL.Vec(IDL.Nat8),
+  });
+  const CreateCanisterAndInstallCodeOk = IDL.Record({
+    canister_id: IDL.Opt(IDL.Principal),
+  });
+  const SuccessfulProposalExecutionValue = IDL.Variant({
+    TakeCanisterSnapshot: TakeCanisterSnapshotOk,
+    CreateCanisterAndInstallCode: CreateCanisterAndInstallCodeOk,
+  });
   const SwapParticipationLimits = IDL.Record({
     min_participant_icp_e8s: IDL.Opt(IDL.Nat64),
     max_participant_icp_e8s: IDL.Opt(IDL.Nat64),
@@ -1478,6 +1516,7 @@ export const init = ({ IDL }) => {
     known_neuron_data: IDL.Opt(KnownNeuronData),
   });
   const FulfillSubnetRentalRequest = IDL.Record({
+    initial_dkg_subnet_id: IDL.Opt(IDL.Principal),
     user: IDL.Opt(IDL.Principal),
     replica_version_id: IDL.Opt(IDL.Text),
     node_ids: IDL.Opt(IDL.Vec(IDL.Principal)),
@@ -1602,6 +1641,7 @@ export const init = ({ IDL }) => {
   });
   const GuestLaunchMeasurementMetadata = IDL.Record({
     kernel_cmdline: IDL.Opt(IDL.Text),
+    vcpu_type: IDL.Opt(IDL.Text),
   });
   const GuestLaunchMeasurement = IDL.Record({
     metadata: IDL.Opt(GuestLaunchMeasurementMetadata),
@@ -1851,6 +1891,7 @@ export const init = ({ IDL }) => {
     proposal_timestamp_seconds: IDL.Nat64,
     reward_event_round: IDL.Nat64,
     failed_timestamp_seconds: IDL.Nat64,
+    success_value: IDL.Opt(SuccessfulProposalExecutionValue),
     neurons_fund_data: IDL.Opt(NeuronsFundData),
     reject_cost_e8s: IDL.Nat64,
     derived_proposal_information: IDL.Opt(DerivedProposalInformation),

--- a/packages/canisters/src/declarations/nns/governance_test.certified.idl.js
+++ b/packages/canisters/src/declarations/nns/governance_test.certified.idl.js
@@ -197,6 +197,16 @@ export const idlFactory = ({ IDL }) => {
     error_type: IDL.Int32,
   });
   const Ballot = IDL.Record({ vote: IDL.Int32, voting_power: IDL.Nat64 });
+  const TakeCanisterSnapshotOk = IDL.Record({
+    snapshot_id: IDL.Vec(IDL.Nat8),
+  });
+  const CreateCanisterAndInstallCodeOk = IDL.Record({
+    canister_id: IDL.Opt(IDL.Principal),
+  });
+  const SuccessfulProposalExecutionValue = IDL.Variant({
+    TakeCanisterSnapshot: TakeCanisterSnapshotOk,
+    CreateCanisterAndInstallCode: CreateCanisterAndInstallCodeOk,
+  });
   const SwapParticipationLimits = IDL.Record({
     min_participant_icp_e8s: IDL.Opt(IDL.Nat64),
     max_participant_icp_e8s: IDL.Opt(IDL.Nat64),
@@ -297,6 +307,7 @@ export const idlFactory = ({ IDL }) => {
     known_neuron_data: IDL.Opt(KnownNeuronData),
   });
   const FulfillSubnetRentalRequest = IDL.Record({
+    initial_dkg_subnet_id: IDL.Opt(IDL.Principal),
     user: IDL.Opt(IDL.Principal),
     replica_version_id: IDL.Opt(IDL.Text),
     node_ids: IDL.Opt(IDL.Vec(IDL.Principal)),
@@ -421,6 +432,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const GuestLaunchMeasurementMetadata = IDL.Record({
     kernel_cmdline: IDL.Opt(IDL.Text),
+    vcpu_type: IDL.Opt(IDL.Text),
   });
   const GuestLaunchMeasurement = IDL.Record({
     metadata: IDL.Opt(GuestLaunchMeasurementMetadata),
@@ -670,6 +682,7 @@ export const idlFactory = ({ IDL }) => {
     proposal_timestamp_seconds: IDL.Nat64,
     reward_event_round: IDL.Nat64,
     failed_timestamp_seconds: IDL.Nat64,
+    success_value: IDL.Opt(SuccessfulProposalExecutionValue),
     neurons_fund_data: IDL.Opt(NeuronsFundData),
     reject_cost_e8s: IDL.Nat64,
     derived_proposal_information: IDL.Opt(DerivedProposalInformation),
@@ -788,6 +801,14 @@ export const idlFactory = ({ IDL }) => {
     Err: GovernanceError,
   });
   const Result_2 = IDL.Variant({ Ok: Neuron, Err: GovernanceError });
+  const GetMaturityModulationRequest = IDL.Record({});
+  const MaturityModulation = IDL.Record({
+    current_value_permyriad: IDL.Opt(IDL.Int32),
+    updated_at_timestamp_seconds: IDL.Opt(IDL.Nat64),
+  });
+  const GetMaturityModulationResponse = IDL.Record({
+    maturity_modulation: IDL.Opt(MaturityModulation),
+  });
   const Result_3 = IDL.Variant({
     Ok: GovernanceCachedMetrics,
     Err: GovernanceError,
@@ -802,6 +823,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const NeuronInfo = IDL.Record({
     id: IDL.Opt(NeuronId),
+    staked_maturity_e8s_equivalent: IDL.Opt(IDL.Nat64),
     dissolve_delay_seconds: IDL.Nat64,
     recent_ballots: IDL.Vec(BallotInfo),
     voting_power_refreshed_timestamp_seconds: IDL.Opt(IDL.Nat64),
@@ -857,6 +879,7 @@ export const idlFactory = ({ IDL }) => {
     reward_event_round: IDL.Nat64,
     deadline_timestamp_seconds: IDL.Opt(IDL.Nat64),
     failed_timestamp_seconds: IDL.Nat64,
+    success_value: IDL.Opt(SuccessfulProposalExecutionValue),
     reject_cost_e8s: IDL.Nat64,
     derived_proposal_information: IDL.Opt(DerivedProposalInformation),
     latest_tally: IDL.Opt(Tally),
@@ -1108,6 +1131,11 @@ export const idlFactory = ({ IDL }) => {
       [],
     ),
     get_latest_reward_event: IDL.Func([], [RewardEvent], []),
+    get_maturity_modulation: IDL.Func(
+      [GetMaturityModulationRequest],
+      [GetMaturityModulationResponse],
+      [],
+    ),
     get_metrics: IDL.Func([], [Result_3], []),
     get_monthly_node_provider_rewards: IDL.Func([], [Result_4], []),
     get_most_recent_monthly_node_provider_rewards: IDL.Func(
@@ -1371,6 +1399,16 @@ export const init = ({ IDL }) => {
     error_type: IDL.Int32,
   });
   const Ballot = IDL.Record({ vote: IDL.Int32, voting_power: IDL.Nat64 });
+  const TakeCanisterSnapshotOk = IDL.Record({
+    snapshot_id: IDL.Vec(IDL.Nat8),
+  });
+  const CreateCanisterAndInstallCodeOk = IDL.Record({
+    canister_id: IDL.Opt(IDL.Principal),
+  });
+  const SuccessfulProposalExecutionValue = IDL.Variant({
+    TakeCanisterSnapshot: TakeCanisterSnapshotOk,
+    CreateCanisterAndInstallCode: CreateCanisterAndInstallCodeOk,
+  });
   const SwapParticipationLimits = IDL.Record({
     min_participant_icp_e8s: IDL.Opt(IDL.Nat64),
     max_participant_icp_e8s: IDL.Opt(IDL.Nat64),
@@ -1471,6 +1509,7 @@ export const init = ({ IDL }) => {
     known_neuron_data: IDL.Opt(KnownNeuronData),
   });
   const FulfillSubnetRentalRequest = IDL.Record({
+    initial_dkg_subnet_id: IDL.Opt(IDL.Principal),
     user: IDL.Opt(IDL.Principal),
     replica_version_id: IDL.Opt(IDL.Text),
     node_ids: IDL.Opt(IDL.Vec(IDL.Principal)),
@@ -1595,6 +1634,7 @@ export const init = ({ IDL }) => {
   });
   const GuestLaunchMeasurementMetadata = IDL.Record({
     kernel_cmdline: IDL.Opt(IDL.Text),
+    vcpu_type: IDL.Opt(IDL.Text),
   });
   const GuestLaunchMeasurement = IDL.Record({
     metadata: IDL.Opt(GuestLaunchMeasurementMetadata),
@@ -1844,6 +1884,7 @@ export const init = ({ IDL }) => {
     proposal_timestamp_seconds: IDL.Nat64,
     reward_event_round: IDL.Nat64,
     failed_timestamp_seconds: IDL.Nat64,
+    success_value: IDL.Opt(SuccessfulProposalExecutionValue),
     neurons_fund_data: IDL.Opt(NeuronsFundData),
     reject_cost_e8s: IDL.Nat64,
     derived_proposal_information: IDL.Opt(DerivedProposalInformation),

--- a/packages/canisters/src/declarations/nns/governance_test.d.ts
+++ b/packages/canisters/src/declarations/nns/governance_test.d.ts
@@ -182,6 +182,9 @@ export interface CreateCanisterAndInstallCode {
   install_arg_hash: [] | [Uint8Array];
   host_subnet_id: [] | [Principal];
 }
+export interface CreateCanisterAndInstallCodeOk {
+  canister_id: [] | [Principal];
+}
 export interface CreateCanisterAndInstallCodeRequest {
   wasm_module: [] | [WasmModule];
   canister_settings: [] | [CanisterSettings];
@@ -313,6 +316,11 @@ export interface FolloweesForTopic {
  */
 export interface FulfillSubnetRentalRequest {
   /**
+   * Optional subnet that should handle `setup_initial_dkg` for subnet creation.
+   * If not set, handling defaults to the NNS subnet.
+   */
+  initial_dkg_subnet_id: [] | [Principal];
+  /**
    * Identifies which rental request to fulfill.
    *
    * (Identifying the rental request by user works, because a user can have at
@@ -343,6 +351,10 @@ export interface FulfillSubnetRentalRequest {
    * Which nodes will be members of the subnet.
    */
   node_ids: [] | [Array<Principal>];
+}
+export type GetMaturityModulationRequest = {};
+export interface GetMaturityModulationResponse {
+  maturity_modulation: [] | [MaturityModulation];
 }
 export interface GetNeuronIndexRequest {
   page_size: [] | [number];
@@ -474,6 +486,10 @@ export interface GuestLaunchMeasurementMetadata {
    * Kernel command line used for this measurement.
    */
   kernel_cmdline: [] | [string];
+  /**
+   * Virtual CPU type used for this measurement.
+   */
+  vcpu_type: [] | [string];
 }
 export interface GuestLaunchMeasurements {
   guest_launch_measurements: [] | [Array<GuestLaunchMeasurement>];
@@ -732,6 +748,10 @@ export interface MaturityDisbursement {
   account_to_disburse_to: [] | [Account];
   finalize_disbursement_timestamp_seconds: [] | [bigint];
 }
+export interface MaturityModulation {
+  current_value_permyriad: [] | [number];
+  updated_at_timestamp_seconds: [] | [bigint];
+}
 export interface Merge {
   source_neuron_id: [] | [NeuronId];
 }
@@ -912,6 +932,10 @@ export interface NeuronIndexData {
  */
 export interface NeuronInfo {
   id: [] | [NeuronId];
+  /**
+   * See analogous field in Neuron.
+   */
+  staked_maturity_e8s_equivalent: [] | [bigint];
   dissolve_delay_seconds: bigint;
   recent_ballots: Array<BallotInfo>;
   voting_power_refreshed_timestamp_seconds: [] | [bigint];
@@ -1118,6 +1142,7 @@ export interface ProposalData {
   proposal_timestamp_seconds: bigint;
   reward_event_round: bigint;
   failed_timestamp_seconds: bigint;
+  success_value: [] | [SuccessfulProposalExecutionValue];
   neurons_fund_data: [] | [NeuronsFundData];
   reject_cost_e8s: bigint;
   derived_proposal_information: [] | [DerivedProposalInformation];
@@ -1144,6 +1169,7 @@ export interface ProposalInfo {
   reward_event_round: bigint;
   deadline_timestamp_seconds: [] | [bigint];
   failed_timestamp_seconds: bigint;
+  success_value: [] | [SuccessfulProposalExecutionValue];
   reject_cost_e8s: bigint;
   derived_proposal_information: [] | [DerivedProposalInformation];
   latest_tally: [] | [Tally];
@@ -1288,6 +1314,11 @@ export interface StopOrStartCanister {
   action: [] | [number];
   canister_id: [] | [Principal];
 }
+export type SuccessfulProposalExecutionValue =
+  | {
+      TakeCanisterSnapshot: TakeCanisterSnapshotOk;
+    }
+  | { CreateCanisterAndInstallCode: CreateCanisterAndInstallCodeOk };
 export interface SwapBackgroundInformation {
   ledger_index_canister_summary: [] | [CanisterSummary];
   fallback_controller_principal_ids: Array<Principal>;
@@ -1328,6 +1359,9 @@ export interface SwapParticipationLimits {
 export interface TakeCanisterSnapshot {
   replace_snapshot: [] | [Uint8Array];
   canister_id: [] | [Principal];
+}
+export interface TakeCanisterSnapshotOk {
+  snapshot_id: Uint8Array;
 }
 export interface Tally {
   no: bigint;
@@ -1447,6 +1481,10 @@ export interface _SERVICE {
     Result_2
   >;
   get_latest_reward_event: ActorMethod<[], RewardEvent>;
+  get_maturity_modulation: ActorMethod<
+    [GetMaturityModulationRequest],
+    GetMaturityModulationResponse
+  >;
   get_metrics: ActorMethod<[], Result_3>;
   get_monthly_node_provider_rewards: ActorMethod<[], Result_4>;
   get_most_recent_monthly_node_provider_rewards: ActorMethod<

--- a/packages/canisters/src/declarations/nns/governance_test.did
+++ b/packages/canisters/src/declarations/nns/governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 2400d84 (2026-04-09) 'packages/canisters/src/declarations/nns/governance_test.did.tmp' by import-candid
+// Generated from IC repo commit 22441dd (2026-06-18) 'packages/canisters/src/declarations/nns/governance_test.did.tmp' by import-candid
 
 type AccountIdentifier = record {
   hash : blob;
@@ -249,6 +249,19 @@ type CreateCanisterAndInstallCodeRequest = record {
   install_arg : opt blob;
 };
 
+type CreateCanisterAndInstallCodeOk = record {
+  canister_id : opt principal;
+};
+
+type TakeCanisterSnapshotOk = record {
+  snapshot_id : blob;
+};
+
+type SuccessfulProposalExecutionValue = variant {
+  CreateCanisterAndInstallCode : CreateCanisterAndInstallCodeOk;
+  TakeCanisterSnapshot : TakeCanisterSnapshotOk;
+};
+
 type CreateServiceNervousSystem = record {
   url : opt text;
   governance_parameters : opt GovernanceParameters;
@@ -321,6 +334,17 @@ type Followees = record {
 
 type GetNeuronsFundAuditInfoRequest = record {
   nns_proposal_id : opt ProposalId;
+};
+
+type MaturityModulation = record {
+  current_value_permyriad : opt int32;
+  updated_at_timestamp_seconds : opt nat64;
+};
+
+type GetMaturityModulationRequest = record {};
+
+type GetMaturityModulationResponse = record {
+  maturity_modulation : opt MaturityModulation;
 };
 
 type GetNeuronsFundAuditInfoResponse = record {
@@ -904,6 +928,8 @@ type NeuronInfo = record {
   potential_voting_power : opt nat64;
   // See analogous field in Neuron.
   eight_year_gang_bonus_base_e8s : opt nat64;
+  // See analogous field in Neuron.
+  staked_maturity_e8s_equivalent : opt nat64;
 };
 
 type NeuronStakeTransfer = record {
@@ -1109,6 +1135,10 @@ type FulfillSubnetRentalRequest = record {
   //
   //     https://github.com/dfinity/ic/releases/latest
   replica_version_id : opt text;
+
+  // Optional subnet that should handle `setup_initial_dkg` for subnet creation.
+  // If not set, handling defaults to the NNS subnet.
+  initial_dkg_subnet_id : opt principal;
 };
 
 // Declares an approved set of alternative replica virtual machine software for
@@ -1143,6 +1173,8 @@ type GuestLaunchMeasurement = record {
 type GuestLaunchMeasurementMetadata = record {
   // Kernel command line used for this measurement.
   kernel_cmdline : opt text;
+  // Virtual CPU type used for this measurement.
+  vcpu_type : opt text;
 };
 
 type TakeCanisterSnapshot = record {
@@ -1170,6 +1202,7 @@ type ProposalData = record {
   original_total_community_fund_maturity_e8s_equivalent : opt nat64;
   total_potential_voting_power : opt nat64;
   topic: opt int32;
+  success_value : opt SuccessfulProposalExecutionValue;
 };
 
 type ProposalInfo = record {
@@ -1191,6 +1224,7 @@ type ProposalInfo = record {
   proposer : opt NeuronId;
   executed_timestamp_seconds : nat64;
   total_potential_voting_power : opt nat64;
+  success_value : opt SuccessfulProposalExecutionValue;
 };
 
 type RegisterVote = record {
@@ -1585,6 +1619,9 @@ service : (Governance) -> {
       Result_2,
     ) query;
   get_latest_reward_event : () -> (RewardEvent) query;
+  get_maturity_modulation : (GetMaturityModulationRequest) -> (
+      GetMaturityModulationResponse,
+    ) query;
   get_metrics : () -> (Result_3) query;
   get_monthly_node_provider_rewards : () -> (Result_4);
   get_most_recent_monthly_node_provider_rewards : () -> (

--- a/packages/canisters/src/declarations/nns/governance_test.idl.js
+++ b/packages/canisters/src/declarations/nns/governance_test.idl.js
@@ -197,6 +197,16 @@ export const idlFactory = ({ IDL }) => {
     error_type: IDL.Int32,
   });
   const Ballot = IDL.Record({ vote: IDL.Int32, voting_power: IDL.Nat64 });
+  const TakeCanisterSnapshotOk = IDL.Record({
+    snapshot_id: IDL.Vec(IDL.Nat8),
+  });
+  const CreateCanisterAndInstallCodeOk = IDL.Record({
+    canister_id: IDL.Opt(IDL.Principal),
+  });
+  const SuccessfulProposalExecutionValue = IDL.Variant({
+    TakeCanisterSnapshot: TakeCanisterSnapshotOk,
+    CreateCanisterAndInstallCode: CreateCanisterAndInstallCodeOk,
+  });
   const SwapParticipationLimits = IDL.Record({
     min_participant_icp_e8s: IDL.Opt(IDL.Nat64),
     max_participant_icp_e8s: IDL.Opt(IDL.Nat64),
@@ -297,6 +307,7 @@ export const idlFactory = ({ IDL }) => {
     known_neuron_data: IDL.Opt(KnownNeuronData),
   });
   const FulfillSubnetRentalRequest = IDL.Record({
+    initial_dkg_subnet_id: IDL.Opt(IDL.Principal),
     user: IDL.Opt(IDL.Principal),
     replica_version_id: IDL.Opt(IDL.Text),
     node_ids: IDL.Opt(IDL.Vec(IDL.Principal)),
@@ -421,6 +432,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const GuestLaunchMeasurementMetadata = IDL.Record({
     kernel_cmdline: IDL.Opt(IDL.Text),
+    vcpu_type: IDL.Opt(IDL.Text),
   });
   const GuestLaunchMeasurement = IDL.Record({
     metadata: IDL.Opt(GuestLaunchMeasurementMetadata),
@@ -670,6 +682,7 @@ export const idlFactory = ({ IDL }) => {
     proposal_timestamp_seconds: IDL.Nat64,
     reward_event_round: IDL.Nat64,
     failed_timestamp_seconds: IDL.Nat64,
+    success_value: IDL.Opt(SuccessfulProposalExecutionValue),
     neurons_fund_data: IDL.Opt(NeuronsFundData),
     reject_cost_e8s: IDL.Nat64,
     derived_proposal_information: IDL.Opt(DerivedProposalInformation),
@@ -788,6 +801,14 @@ export const idlFactory = ({ IDL }) => {
     Err: GovernanceError,
   });
   const Result_2 = IDL.Variant({ Ok: Neuron, Err: GovernanceError });
+  const GetMaturityModulationRequest = IDL.Record({});
+  const MaturityModulation = IDL.Record({
+    current_value_permyriad: IDL.Opt(IDL.Int32),
+    updated_at_timestamp_seconds: IDL.Opt(IDL.Nat64),
+  });
+  const GetMaturityModulationResponse = IDL.Record({
+    maturity_modulation: IDL.Opt(MaturityModulation),
+  });
   const Result_3 = IDL.Variant({
     Ok: GovernanceCachedMetrics,
     Err: GovernanceError,
@@ -802,6 +823,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const NeuronInfo = IDL.Record({
     id: IDL.Opt(NeuronId),
+    staked_maturity_e8s_equivalent: IDL.Opt(IDL.Nat64),
     dissolve_delay_seconds: IDL.Nat64,
     recent_ballots: IDL.Vec(BallotInfo),
     voting_power_refreshed_timestamp_seconds: IDL.Opt(IDL.Nat64),
@@ -857,6 +879,7 @@ export const idlFactory = ({ IDL }) => {
     reward_event_round: IDL.Nat64,
     deadline_timestamp_seconds: IDL.Opt(IDL.Nat64),
     failed_timestamp_seconds: IDL.Nat64,
+    success_value: IDL.Opt(SuccessfulProposalExecutionValue),
     reject_cost_e8s: IDL.Nat64,
     derived_proposal_information: IDL.Opt(DerivedProposalInformation),
     latest_tally: IDL.Opt(Tally),
@@ -1108,6 +1131,11 @@ export const idlFactory = ({ IDL }) => {
       ["query"],
     ),
     get_latest_reward_event: IDL.Func([], [RewardEvent], ["query"]),
+    get_maturity_modulation: IDL.Func(
+      [GetMaturityModulationRequest],
+      [GetMaturityModulationResponse],
+      ["query"],
+    ),
     get_metrics: IDL.Func([], [Result_3], ["query"]),
     get_monthly_node_provider_rewards: IDL.Func([], [Result_4], []),
     get_most_recent_monthly_node_provider_rewards: IDL.Func(
@@ -1379,6 +1407,16 @@ export const init = ({ IDL }) => {
     error_type: IDL.Int32,
   });
   const Ballot = IDL.Record({ vote: IDL.Int32, voting_power: IDL.Nat64 });
+  const TakeCanisterSnapshotOk = IDL.Record({
+    snapshot_id: IDL.Vec(IDL.Nat8),
+  });
+  const CreateCanisterAndInstallCodeOk = IDL.Record({
+    canister_id: IDL.Opt(IDL.Principal),
+  });
+  const SuccessfulProposalExecutionValue = IDL.Variant({
+    TakeCanisterSnapshot: TakeCanisterSnapshotOk,
+    CreateCanisterAndInstallCode: CreateCanisterAndInstallCodeOk,
+  });
   const SwapParticipationLimits = IDL.Record({
     min_participant_icp_e8s: IDL.Opt(IDL.Nat64),
     max_participant_icp_e8s: IDL.Opt(IDL.Nat64),
@@ -1479,6 +1517,7 @@ export const init = ({ IDL }) => {
     known_neuron_data: IDL.Opt(KnownNeuronData),
   });
   const FulfillSubnetRentalRequest = IDL.Record({
+    initial_dkg_subnet_id: IDL.Opt(IDL.Principal),
     user: IDL.Opt(IDL.Principal),
     replica_version_id: IDL.Opt(IDL.Text),
     node_ids: IDL.Opt(IDL.Vec(IDL.Principal)),
@@ -1603,6 +1642,7 @@ export const init = ({ IDL }) => {
   });
   const GuestLaunchMeasurementMetadata = IDL.Record({
     kernel_cmdline: IDL.Opt(IDL.Text),
+    vcpu_type: IDL.Opt(IDL.Text),
   });
   const GuestLaunchMeasurement = IDL.Record({
     metadata: IDL.Opt(GuestLaunchMeasurementMetadata),
@@ -1852,6 +1892,7 @@ export const init = ({ IDL }) => {
     proposal_timestamp_seconds: IDL.Nat64,
     reward_event_round: IDL.Nat64,
     failed_timestamp_seconds: IDL.Nat64,
+    success_value: IDL.Opt(SuccessfulProposalExecutionValue),
     neurons_fund_data: IDL.Opt(NeuronsFundData),
     reject_cost_e8s: IDL.Nat64,
     derived_proposal_information: IDL.Opt(DerivedProposalInformation),

--- a/packages/canisters/src/declarations/nns/sns_wasm.did
+++ b/packages/canisters/src/declarations/nns/sns_wasm.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit b4b0230 (2026-04-09 tags: release-2026-04-10_04-17-base) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
+// Generated from IC repo commit 93274f1 (2026-06-15 tags: release-2026-06-12_04-52-hotfix) 'rs/nns/sns-wasm/canister/sns-wasm.did' by import-candid
 
 type AddWasmRequest = record {
   hash : blob;

--- a/packages/canisters/src/declarations/sns/governance.did
+++ b/packages/canisters/src/declarations/sns/governance.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 606cab7 (2026-04-01 tags: release-2026-04-02_04-48-base) 'rs/sns/governance/canister/governance.did' by import-candid
+// Generated from IC repo commit 93274f1 (2026-06-15 tags: release-2026-06-12_04-52-hotfix) 'rs/sns/governance/canister/governance.did' by import-candid
 
 type Account = record {
   owner : opt principal;

--- a/packages/canisters/src/declarations/sns/governance_test.did
+++ b/packages/canisters/src/declarations/sns/governance_test.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 0a6603f (2026-03-31) 'packages/canisters/src/declarations/sns/governance_test.did.tmp' by import-candid
+// Generated from IC repo commit 22441dd (2026-06-18) 'packages/canisters/src/declarations/sns/governance_test.did.tmp' by import-candid
 
 type Account = record {
   owner : opt principal;

--- a/packages/canisters/src/declarations/sns/root.did
+++ b/packages/canisters/src/declarations/sns/root.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 606cab7 (2026-04-01 tags: release-2026-04-02_04-48-base) 'rs/sns/root/canister/root.did' by import-candid
+// Generated from IC repo commit 93274f1 (2026-06-15 tags: release-2026-06-12_04-52-hotfix) 'rs/sns/root/canister/root.did' by import-candid
 
 type CanisterCallError = record {
   code : opt int32;

--- a/packages/canisters/src/declarations/sns/swap.did
+++ b/packages/canisters/src/declarations/sns/swap.did
@@ -1,4 +1,4 @@
-// Generated from IC repo commit 606cab7 (2026-04-01 tags: release-2026-04-02_04-48-base) 'rs/sns/swap/canister/swap.did' by import-candid
+// Generated from IC repo commit 93274f1 (2026-06-15 tags: release-2026-06-12_04-52-hotfix) 'rs/sns/swap/canister/swap.did' by import-candid
 
 type BuyerState = record {
   icp : opt TransferableAmount;

--- a/packages/canisters/src/ledger/icrc/index.canister.spec.ts
+++ b/packages/canisters/src/ledger/icrc/index.canister.spec.ts
@@ -48,6 +48,8 @@ describe("Index canister", () => {
           },
         ],
         approve: [],
+        authorized_burn: [],
+        authorized_mint: [],
         fee_collector: [],
       };
       const transactionWithId = {

--- a/packages/canisters/src/nns/canisters/governance/request.converters.spec.ts
+++ b/packages/canisters/src/nns/canisters/governance/request.converters.spec.ts
@@ -714,6 +714,7 @@ describe("request.converters", () => {
             measurement: Uint8Array.from([4, 5, 6]),
             metadata: {
               kernelCmdline: "kernel_cmdline",
+              vcpuType: "vcpu_type",
             },
           },
         ],
@@ -755,6 +756,7 @@ describe("request.converters", () => {
                               metadata: [
                                 {
                                   kernel_cmdline: ["kernel_cmdline"],
+                                  vcpu_type: ["vcpu_type"],
                                 },
                               ],
                             },

--- a/packages/canisters/src/nns/canisters/governance/request.converters.ts
+++ b/packages/canisters/src/nns/canisters/governance/request.converters.ts
@@ -662,6 +662,7 @@ const fromAction = (
                               kernel_cmdline: toNullable(
                                 m.metadata.kernelCmdline,
                               ),
+                              vcpu_type: toNullable(m.metadata.vcpuType),
                             }
                           : undefined,
                       ),

--- a/packages/canisters/src/nns/canisters/governance/response.converters.spec.ts
+++ b/packages/canisters/src/nns/canisters/governance/response.converters.spec.ts
@@ -590,6 +590,7 @@ describe("response.converters", () => {
       const rootfsHash = "rootfs_hash";
       const measurement = Uint8Array.from([4, 5, 6]);
       const kernelCmdline = "kernel_cmdline";
+      const vcpuType = "vcpu_type";
 
       const candidProposalInfo: NnsGovernanceDid.ProposalInfo = {
         id: [{ id: 100n }],
@@ -618,6 +619,7 @@ describe("response.converters", () => {
                             metadata: [
                               {
                                 kernel_cmdline: [kernelCmdline],
+                                vcpu_type: [vcpuType],
                               },
                             ],
                           },
@@ -665,6 +667,7 @@ describe("response.converters", () => {
                     measurement,
                     metadata: {
                       kernelCmdline,
+                      vcpuType,
                     },
                   },
                 ],

--- a/packages/canisters/src/nns/canisters/governance/response.converters.spec.ts
+++ b/packages/canisters/src/nns/canisters/governance/response.converters.spec.ts
@@ -112,6 +112,7 @@ describe("response.converters", () => {
     voting_power: 0n,
     age_seconds: 0n,
     eight_year_gang_bonus_base_e8s: [32n],
+    staked_maturity_e8s_equivalent: [],
   };
 
   const defaultNeuronInfo: NeuronInfo = {
@@ -642,6 +643,7 @@ describe("response.converters", () => {
         reward_status: 1,
         total_potential_voting_power: [],
         failure_reason: [],
+        success_value: [],
         derived_proposal_information: [],
       };
 
@@ -728,6 +730,7 @@ describe("response.converters", () => {
         reward_status: 1,
         total_potential_voting_power: [],
         failure_reason: [],
+        success_value: [],
         derived_proposal_information: [],
       };
 
@@ -803,6 +806,7 @@ describe("response.converters", () => {
         reward_status: 1,
         total_potential_voting_power: [],
         failure_reason: [],
+        success_value: [],
         derived_proposal_information: [],
       };
 
@@ -894,6 +898,7 @@ describe("response.converters", () => {
         reward_status: 1,
         total_potential_voting_power: [],
         failure_reason: [],
+        success_value: [],
         derived_proposal_information: [],
       };
 
@@ -999,6 +1004,7 @@ describe("response.converters", () => {
         reward_status: 1,
         total_potential_voting_power: [],
         failure_reason: [],
+        success_value: [],
         derived_proposal_information: [],
       };
 
@@ -1055,6 +1061,7 @@ describe("response.converters", () => {
         reward_status: 1,
         total_potential_voting_power: [],
         failure_reason: [],
+        success_value: [],
         derived_proposal_information: [],
       };
 

--- a/packages/canisters/src/nns/canisters/governance/response.converters.ts
+++ b/packages/canisters/src/nns/canisters/governance/response.converters.ts
@@ -707,7 +707,10 @@ const toAction = (action: NnsGovernanceDid.Action): Action => {
                 return {
                   measurement: fromNullable(m.measurement),
                   metadata: nonNullish(metadata)
-                    ? { kernelCmdline: fromNullable(metadata.kernel_cmdline) }
+                    ? {
+                        kernelCmdline: fromNullable(metadata.kernel_cmdline),
+                        vcpuType: fromNullable(metadata.vcpu_type),
+                      }
                     : undefined,
                 };
               }),

--- a/packages/canisters/src/nns/mocks/governance.mock.ts
+++ b/packages/canisters/src/nns/mocks/governance.mock.ts
@@ -21,6 +21,7 @@ export const mockNeuronInfo: NnsGovernanceDid.NeuronInfo = {
   potential_voting_power: [one],
   deciding_voting_power: [one],
   eight_year_gang_bonus_base_e8s: [one],
+  staked_maturity_e8s_equivalent: [one],
 };
 export const mockNeuron: NnsGovernanceDid.Neuron = {
   id: [{ id: mockNeuronId }],

--- a/packages/canisters/src/nns/types/governance_converters.ts
+++ b/packages/canisters/src/nns/types/governance_converters.ts
@@ -322,6 +322,7 @@ export interface FulfillSubnetRentalRequest {
 }
 export interface GuestLaunchMeasurementMetadata {
   kernelCmdline: Option<string>;
+  vcpuType: Option<string>;
 }
 export interface GuestLaunchMeasurement {
   metadata: Option<GuestLaunchMeasurementMetadata>;


### PR DESCRIPTION
# Motivation

The canisters APIs have been updated.

This re-opens the automated IC Candid update originally generated in #1530 under a human author, because the update requires hand-written changes to non-generated files (converters, fixtures, size limits, changelog) that the PR automation bot is not allowed to push — see the `Check Bot Policies` guardrail failure on #1530.

# Changes

* Updated the candid interface files for the canisters used in this library.
* Updated the javascript bindings for the latest candid interfaces.
* NNS: map the new `vcpuType` field on `GuestLaunchMeasurement` metadata through the `BlessAlternativeGuestOsVersion` request/response converters.
* Updated test fixtures/mocks for new optional Candid fields (`NeuronInfo.staked_maturity_e8s_equivalent`, `ProposalInfo.success_value`, `Transaction.authorized_burn`/`authorized_mint`).
* Bumped the `@dfinity/ckbtc` size limit to 10 kB to accommodate the larger minter interface.
* Added a CHANGELOG entry.

# Tests

  - [ ] Please check the API updates for any breaking changes that affect our code.
